### PR TITLE
Fix script generation in a for loop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     compile 'org.clojure:core.async:0.1.267.0-0d7780-alpha'
     compile 'clj-time:clj-time:0.5.0'
     compile 'instaparse:instaparse:1.2.14'
-    compile 'com.taoensso:nippy:2.6.0-beta2'
+    compile 'com.taoensso:nippy:2.6.0-RC1'
     compile 'rhizome:rhizome:0.1.9'
     compile 'com.netflix.rxjava:rxjava-core:0.9.2'
     compile 'com.netflix.rxjava:rxjava-clojure:0.9.2'

--- a/src/main/clojure/pigpen/code.clj
+++ b/src/main/clojure/pigpen/code.clj
@@ -21,7 +21,9 @@
 or reduce."
   (:require [pigpen.pig :as pig]
             [pigpen.raw :as raw]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [taoensso.nippy :as nippy]
+            [taoensso.nippy.utils :as nippy-util])
   (:import [org.apache.pig.data DataBag]
            [java.lang.reflect Method]))
 
@@ -77,6 +79,9 @@ or reduce."
     (:pig (meta v)) nil
     (:local (meta v)) nil
     (:local (meta k)) nil
+    (not (nippy-util/readable? v)) nil
+    ;; TODO if something is freezable, but not EDN friendly, maybe use a base64 string?
+    ;(nippy/freezeable? v) [k `(thaw (decode ~(encode (freeze v))))]
     :else [k `(quote ~v)]))
 
 (defn ns-exists

--- a/src/test/clojure/pigpen/local_test.clj
+++ b/src/test/clojure/pigpen/local_test.clj
@@ -315,6 +315,15 @@
     (is (= (exec/dump command)
            [1 1 1 2 2 2 3 3 3]))))
 
+(deftest test-for
+  (is (= (pigpen.exec/dump
+           (apply pig-set/concat
+             (for [x [1 2 3]]
+               (->>
+                 (io/return [1 2 3])
+                 (pig-map/map (fn [y] (+ x y)))))))
+         [4 3 2 5 4 3 6 5 4])))
+
 ;; ********** Filter **********
 
 (deftest test-filter


### PR DESCRIPTION
When a Clojure `for` macro expands, it adds quite a few local variables. Some of these are not serializable. This checks for anything that doesn't appear to be EDN friendly and excludes it. 
