### PR TITLE
Fix handling of pig's implicit dereferencing within group-all

### DIFF
--- a/src/main/clojure/pigpen/local.clj
+++ b/src/main/clojure/pigpen/local.clj
@@ -345,8 +345,10 @@ See pigpen.core and pigpen.exec
     ^List
     (mapv (fn [[r v] ^Observable d]
             (.map d (fn [values]
-                      {:values (pig/tuple (v values))
-                       :relation [r v]})))  
+                      ;; TODO clean up pig dereferencing
+                      (let [v' (v values)]
+                        {:values (if (instance? Tuple v') v' (pig/tuple v'))
+                         :relation [r v]}))))
          (next fields) data)
     (Observable/merge)
     (.groupBy :relation)

--- a/src/test/clojure/pigpen/local_test.clj
+++ b/src/test/clojure/pigpen/local_test.clj
@@ -324,6 +324,20 @@
                  (pig-map/map (fn [y] (+ x y)))))))
          [4 3 2 5 4 3 6 5 4])))
 
+(deftest test-map+fold
+  (is (= (pigpen.exec/dump
+           (->> (io/return [-2 -1 0 1 2])
+             (pig-map/map #(> % 0))
+             (pig-join/fold (->> (fold/filter identity) (fold/count)))))
+         [2])))
+
+(deftest test-map+reduce
+  (is (= (pigpen.exec/dump
+           (->> (io/return [-2 -1 0 1 2])
+             (pig-map/map inc)
+             (pig-join/fold (->> (fold/filter #(> % 0)) (fold/count)))))
+         [3])))
+
 ;; ********** Filter **********
 
 (deftest test-filter


### PR DESCRIPTION
Pig has an implicit behavior of dereferencing values within a tuple. This behavior was missing in the local implementation of group-all, causing every value to be wrapped in a vector when run locally.
