### PR TITLE
Fix bug where the arity check was incorrectly checking varargs functions

### DIFF
--- a/src/main/clojure/pigpen/code.clj
+++ b/src/main/clojure/pigpen/code.clj
@@ -41,7 +41,7 @@ or reduce."
                 set)
         varargs (->> methods
                   (filter (fn [^Method m] (= "doInvoke" (.getName m))))
-                  (map (fn [^Method m] (-> m .getParameterTypes alength)))
+                  (map (fn [^Method m] (-> m .getParameterTypes alength dec)))
                   first)]
     [fixed varargs]))
 

--- a/src/main/clojure/pigpen/join.clj
+++ b/src/main/clojure/pigpen/join.clj
@@ -47,6 +47,7 @@ coerced to ::nil so they can be differentiated from outer joins later."
       (raw/generate$ [(raw/projection-field$ 0 'key)
                       (raw/projection-field$ 1 'value)] {}))))
 
+;; TODO verify these are vetted at compile time
 (defn fold-fn*
   "See pigpen.core/fold-fn"
   [pre combinef reducef post]

--- a/src/test/clojure/pigpen/code_test.clj
+++ b/src/test/clojure/pigpen/code_test.clj
@@ -34,12 +34,11 @@
     (let [f '(fn
                ([] nil)
                ([a] nil)
-               ([a b] nil)
                ([a b c & more] nil))]
       (pig/assert-arity f 0)
       (pig/assert-arity f 1)
-      (pig/assert-arity f 2)
-      (is (thrown? java.lang.AssertionError (pig/assert-arity f 3)))
+      (is (thrown? java.lang.AssertionError (pig/assert-arity f 2)))
+      (pig/assert-arity f 3)
       (pig/assert-arity f 4)
       (pig/assert-arity f 5)))
   
@@ -54,6 +53,12 @@
       (is (thrown? java.lang.AssertionError (pig/assert-arity f 1)))
       (pig/assert-arity f 2)
       (is (thrown? java.lang.AssertionError (pig/assert-arity f 3)))))
+
+  (testing "varargs zero"
+    (let [f (fn [& args] nil)]
+      (pig/assert-arity f 0)
+      (pig/assert-arity f 1)
+      (pig/assert-arity f 2)))
   
   (testing "bad fn"
     (is (thrown? clojure.lang.Compiler$CompilerException (pig/assert-arity 'f 0)))


### PR DESCRIPTION
varargs should count for 0 or more extra args, not one or more.

Facepalm :)
