### PR TITLE
PigPenFnAlgebraic shouldn't implement Accumulator

### DIFF
--- a/src/main/java/pigpen/PigPenFnAlgebraic.java
+++ b/src/main/java/pigpen/PigPenFnAlgebraic.java
@@ -37,10 +37,13 @@ import clojure.lang.Var;
  * @author mbossenbroek
  *
  */
-public class PigPenFnAlgebraic extends PigPenFn<DataByteArray> implements Algebraic {
+public class PigPenFnAlgebraic extends EvalFunc<DataByteArray> implements Algebraic {
+
+    protected final String init, func;
 
     public PigPenFnAlgebraic(String init, String func) {
-        super(init, func);
+        this.init = init;
+        this.func = func;
     }
 
     private static final IFn ALGEBRAIC;


### PR DESCRIPTION
Pig, it turns out, doesn't support folding more than one grouping at a time. This means that a group-by fold will work as expected, but a cogroup with two or more relations will fall back to a non-folding interface.

This was causing Pig to fall back to the Accumulator interface, which is not compatible with Algebraic at the moment. The effect of this is that it would return nil for each fold operation instead of the value.

This is a stop-gap solution in that it will return the correct result, but it might not be as efficient. The long-term solution is to compute two independent group-by/fold operations and then a final cogroup to bring the folded results together. Obviously, this will come with a large disclaimer that it will create 3+ hadoop jobs.
