### PR TITLE
Update debug to ignore anonymous projections

### DIFF
--- a/src/main/clojure/pigpen/oven.clj
+++ b/src/main/clojure/pigpen/oven.clj
@@ -286,11 +286,12 @@ See pigpen.core and pigpen.exec
    available"
   [command location]
   (when-let [field-type (or (:field-type command) (:field-type-out command))]
-    (-> command
-      (raw/bind$ [] `(pigpen.pig/map->bind pigpen.pig/debug)
-                 {:args (:fields command), :field-type-in field-type, :field-type-out :native})
-      ;; TODO Fix the location of store commands to match generates instead of binds
-      (raw/store$ (str location (:id command)) raw/default-storage {}))))
+    (when-not (get-in command [:opts :implicit-schema])
+      (-> command
+        (raw/bind$ [] `(pigpen.pig/map->bind pigpen.pig/debug)
+                   {:args (:fields command), :field-type-in field-type, :field-type-out :native})
+        ;; TODO Fix the location of store commands to match generates instead of binds
+        (raw/store$ (str location (:id command)) raw/default-storage {})))))
 
 (defn ^:private debug
   "Creates a debug version of a script. This adds a store command after every command."


### PR DESCRIPTION
Debug mode was broken when I changed key-selector code to use bind operations for performace gains.

The problem comes from Pig's inability to use a schema at that point, so I just disabled debugging for that intermediate command. It's actually better for debug mode, which would have written the same data twice.
