### PR TITLE
Add partition-by, initially only to distinct

### DIFF
--- a/src/main/clojure/pigpen/exec.clj
+++ b/src/main/clojure/pigpen/exec.clj
@@ -58,10 +58,9 @@ combine them. Optionally takes a map of options.
   {:added "0.1.0"}
   ([script] (generate-script {} script))
   ([opts script]
-    (as-> script %
-      (oven/bake % opts)
-      (map script/command->script %)
-      (apply str %))))
+    (-> script
+      (oven/bake opts)
+      script/commands->script)))
 
 (defn write-script
   "Generates a Pig script from the relation specified and writes it to location.

--- a/src/main/clojure/pigpen/set.clj
+++ b/src/main/clojure/pigpen/set.clj
@@ -75,7 +75,7 @@
   [s0 & more]
   (drop (->> more (map count) (reduce +)) s0))
 
-(defn distinct
+(defmacro distinct
   "Returns a relation with the distinct values of relation. Optionally takes a
 map of options.
 
@@ -87,13 +87,16 @@ map of options.
   Options:
 
     :parallel - The degree of parallelism to use
+    :partition-by - A partition function to use. Should take the form:
+      (fn [n key] (mod (hash key) n)) Where n is the number of partitions and
+      key is the key to partition.
 
   See also: pigpen.core/union, pigpen.core/union-multiset, pigpen.core/filter
 "
   {:added "0.1.0"}
-  ([relation] (distinct {} relation))
+  ([relation] `(distinct {} ~relation))
   ([opts relation]
-    (raw/distinct$ relation opts)))
+    `(raw/distinct$ ~relation ~(code/trap-values #{:partition-by} opts))))
 
 (defn union
   "Performs a union on all relations provided and returns the distinct results.

--- a/src/main/java/pigpen/PigPenPartitioner.java
+++ b/src/main/java/pigpen/PigPenPartitioner.java
@@ -1,0 +1,48 @@
+package pigpen;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.Partitioner;
+import org.apache.pig.impl.io.PigNullableWritable;
+import org.apache.pig.impl.util.UDFContext;
+
+import clojure.lang.IFn;
+import clojure.lang.RT;
+import clojure.lang.Symbol;
+import clojure.lang.Var;
+
+/**
+ * The base class for partitioners in PigPen
+ *
+ * @author mbossenbroek
+ *
+ */
+public abstract class PigPenPartitioner extends Partitioner<PigNullableWritable, Writable> {
+
+    private static final IFn EVAL_STRING, GET_PARTITION;
+
+    static {
+        final Var require = RT.var("clojure.core", "require");
+        require.invoke(Symbol.intern("pigpen.pig"));
+        EVAL_STRING = RT.var("pigpen.pig", "eval-string");
+        GET_PARTITION = RT.var("pigpen.pig", "get-partition");
+    }
+
+    private final String type;
+    private final Object func;
+
+    public PigPenPartitioner() {
+        final Configuration jobConf = UDFContext.getUDFContext().getJobConf();
+        type = jobConf.get(getClass().getSimpleName() + "_type");
+        final String init = jobConf.get(getClass().getSimpleName() + "_init");
+        final String func = jobConf.get(getClass().getSimpleName() + "_func");
+
+        EVAL_STRING.invoke(init);
+        this.func = EVAL_STRING.invoke(func);
+    }
+
+    @Override
+    public int getPartition(final PigNullableWritable key, final Writable value, final int numPartitions) {
+        return (Integer) GET_PARTITION.invoke(type, func, key.getValueAsPigType(), numPartitions);
+    }
+}


### PR DESCRIPTION
@daveray @pathaks @johnmidgley

Added a `:partition-by` option to `distinct`. It should be relatively easy to add partitioners to other operators that could take them, but I only needed `distinct` for now.

Unfortunately, Hadoop doesn't allow for parameters to be passed to partition functions, so the workaround was to generate many of them. Right now it makes 32 of them, but this can be easily changed if there is a need. This also introduces state into the script generation process (which partitioner to use), which is now explicitly passed through that command.

The generated partitioners all extend the same base class and determine which config to load based on their name, which includes a numerical index.
