### PR TITLE
Make oven/bake idempotent & public / Remove dump&show as unnecessary

### DIFF
--- a/src/main/clojure/pigpen/core.clj
+++ b/src/main/clojure/pigpen/core.clj
@@ -104,8 +104,5 @@ if you have a single output.
 (intern *ns* (with-meta 'generate-script (meta #'pigpen.exec/generate-script)) @#'pigpen.exec/generate-script)
 (intern *ns* (with-meta 'write-script (meta #'pigpen.exec/write-script)) @#'pigpen.exec/write-script)
 (intern *ns* (with-meta 'dump (meta #'pigpen.exec/dump)) @#'pigpen.exec/dump)
-(intern *ns* (with-meta 'dump-async (meta #'pigpen.exec/dump-async)) @#'pigpen.exec/dump-async)
 (intern *ns* (with-meta 'show (meta #'pigpen.exec/show)) @#'pigpen.exec/show)
 (intern *ns* (with-meta 'show+ (meta #'pigpen.exec/show+)) @#'pigpen.exec/show+)
-(intern *ns* (with-meta 'dump&show (meta #'pigpen.exec/dump&show)) @#'pigpen.exec/dump&show)
-(intern *ns* (with-meta 'dump&show+ (meta #'pigpen.exec/dump&show+)) @#'pigpen.exec/dump&show+)

--- a/src/main/clojure/pigpen/local.clj
+++ b/src/main/clojure/pigpen/local.clj
@@ -107,7 +107,7 @@ See pigpen.core and pigpen.exec
       (let [[id _ :as o] (some (find-next-o (into {} observables)) (vals command-lookup))]
         (recur (dissoc command-lookup id) (conj observables o))))))
 
-(defn ^Observable dereference-all [^Observable o]
+(defn dereference-all ^Observable [^Observable o]
   (.map o #(->> %
              (map (fn [[k v]] [k (dereference v)]))
              (into {}))))
@@ -118,13 +118,15 @@ See pigpen.core and pigpen.exec
     seq
     vec))
 
-(defn ^Observable observable->data [^Observable o]
+(defn observable->data
+  ^Observable [^Observable o]
   (-> o
     (dereference-all)
     (.map (comp 'value pig/thaw-values))
     observable->clj))
 
-(defn ^Observable observable->raw-data [^Observable o]
+(defn observable->raw-data
+  ^Observable [^Observable o]
   (-> o
     (dereference-all)
     (.map pig/thaw-anything)

--- a/src/main/clojure/pigpen/viz.clj
+++ b/src/main/clojure/pigpen/viz.clj
@@ -49,7 +49,7 @@ See pigpen.core and pigpen.exec
       (str label' "\\l...")
       label')))
 
-(defn view-graph [commands command->description]
+(defn view-graph [command->description commands]
   (viz/view-graph (filter #(contains? % :id) commands)
                   (fn [parent] (filter (fn [child] ((-> child :ancestors set) (:id parent))) commands))
                   :node->descriptor (fn [c] {:label (fix-label (command->description c))

--- a/src/test/clojure/pigpen/local_test.clj
+++ b/src/test/clojure/pigpen/local_test.clj
@@ -107,7 +107,7 @@
                     (io/store-clj "build/local-test/test-debug-out"))]
       (spit "build/local-test/test-debug-in" "{:a 1, :b \"foo\"}\n{:a 2, :b \"bar\"}")
       #_(exec/write-script "build/local-test/temp.pig" {:debug "build/local-test/"} command)
-      (is (empty? (exec/dump-debug "build/local-test/test-debug-" command)))
+      (is (empty? (exec/dump {:debug "build/local-test/test-debug-"} command)))
       (is (= "class java.lang.String\t{:a 1, :b \"foo\"}\nclass java.lang.String\t{:a 2, :b \"bar\"}\n"
             (slurp "build/local-test/test-debug-load1")))
       (is (= "class clojure.lang.PersistentArrayMap\t{:a 1, :b \"foo\"}\nclass clojure.lang.PersistentArrayMap\t{:a 2, :b \"bar\"}\n"


### PR DESCRIPTION
Prior to this change, it was difficult to have multiple outputs with the same ids because the oven would re-generate a number of steps. It also produced awkward commands like `dump&show`, which I never liked.

See `pigpen.oven/bake` for example usage.

Also removed `dump-async` because it was broken & a bad idea to begin with. And cleaned up some type hinting that was doing nothing.
