### PR TITLE
Fix self-joins with the same key (which are rare & pointless)

### DIFF
--- a/src/test/clojure/pigpen/local_test.clj
+++ b/src/test/clojure/pigpen/local_test.clj
@@ -992,15 +992,29 @@
          (freeze [{:k :i, :v 7} {:k :i, :v 6}])
          (freeze [{:k :i, :v 7} {:k :i, :v 8}])})))
 
-;; TODO make this work
-#_(deftest test-join-self
-   (let [data (pig/return [0 1 2])
-         data-fn (fn [n] (pig/return [1 2 3]))
-         command (pig/join [(data :on identity)
-                            ((data-fn 3) :on identity)]
-                           vector)]
-     (is (= (pig/dump command)
-            [[2 2] [0 0] [1 1]]))))
+(deftest test-join-self
+  (let [data (io/return [0 1 2])
+        command (pig-join/join [(data)
+                                (data)]
+                               vector)]
+    (is (= (exec/dump command)
+           [[2 2] [0 0] [1 1]]))))
+
+(deftest test-cogroup-self
+  (let [data (io/return [0 1 2])
+        command (pig-join/cogroup [(data)
+                                   (data)]
+                                  vector)]
+    (is (= (exec/dump command)
+           '[[2 (2) (2)] [0 (0) (0)] [1 (1) (1)]]))))
+
+(deftest test-cogroup-self+fold
+  (let [data (io/return [0 1 2])
+        command (pig-join/cogroup [(data :fold (fold/count))
+                                   (data :fold (fold/count))]
+                                  vector)]
+    (is (= (exec/dump command)
+           '[[2 1 1] [0 1 1] [1 1 1]]))))
 
 (deftest test-join-inner
   (let [data1 (io/return [{:k nil, :v 1}


### PR DESCRIPTION
This fixes the situation where you were to join a relation to itself on the same join key. This type of join is pointless because you end up with a duplicate of the data and a lot of extra work, but it can arise if you're doing dynamically generated joins.

The strategy for the fix is to assign new ids to key selectors for joins such as this. This makes all input joins appear to be different relations. The values passed to the combining function simply use one of the duplicates because they are identical.
