### PR TITLE
Split local-test into separate functional-test namespaces

### DIFF
--- a/src/main/clojure/pigpen/exec.clj
+++ b/src/main/clojure/pigpen/exec.clj
@@ -95,14 +95,6 @@ combine them. Optionally takes a map of options.
       (oven/bake opts)
       (local/graph->observable))))
 
-(defn debug-script-raw [query]
-  (->> query
-    query->observable
-    local/observable->raw-data))
-
-(defn debug-script [query]
-  (map 'value (debug-script-raw query)))
-
 ;; TODO add a version that returns a multiset
 (defn dump
   "Executes a script locally and returns the resulting values as a clojure

--- a/src/test/clojure/pigpen/functional/code_test.clj
+++ b/src/test/clojure/pigpen/functional/code_test.clj
@@ -1,0 +1,47 @@
+;;
+;;
+;;  Copyright 2013 Netflix, Inc.
+;;
+;;     Licensed under the Apache License, Version 2.0 (the "License");
+;;     you may not use this file except in compliance with the License.
+;;     You may obtain a copy of the License at
+;;
+;;         http://www.apache.org/licenses/LICENSE-2.0
+;;
+;;     Unless required by applicable law or agreed to in writing, software
+;;     distributed under the License is distributed on an "AS IS" BASIS,
+;;     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;;     See the License for the specific language governing permissions and
+;;     limitations under the License.
+;;
+;;
+
+(ns pigpen.functional.code-test
+  (:use clojure.test)
+  (:require [pigpen.extensions.test :refer [test-diff]]
+            [pigpen.core :as pig]
+            [pigpen.fold :as fold]))
+
+(defn test-fn [x]
+  (* x x))
+
+(defn test-param [y data]
+  (let [z 42]
+    (->> data
+      (pig/map (fn [x] (+ (test-fn x) y z))))))
+
+(deftest test-closure
+  (let [data (pig/return [1 2 3])
+        command (test-param 37 data)]
+    (test-diff
+      (pig/dump command)
+      '[80 83 88])))
+
+(deftest test-for
+  (is (= (pig/dump
+           (apply pig/concat
+             (for [x [1 2 3]]
+               (->>
+                 (pig/return [1 2 3])
+                 (pig/map (fn [y] (+ x y)))))))
+         [4 3 2 5 4 3 6 5 4])))

--- a/src/test/clojure/pigpen/functional/filter_test.clj
+++ b/src/test/clojure/pigpen/functional/filter_test.clj
@@ -1,0 +1,39 @@
+;;
+;;
+;;  Copyright 2013 Netflix, Inc.
+;;
+;;     Licensed under the Apache License, Version 2.0 (the "License");
+;;     you may not use this file except in compliance with the License.
+;;     You may obtain a copy of the License at
+;;
+;;         http://www.apache.org/licenses/LICENSE-2.0
+;;
+;;     Unless required by applicable law or agreed to in writing, software
+;;     distributed under the License is distributed on an "AS IS" BASIS,
+;;     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;;     See the License for the specific language governing permissions and
+;;     limitations under the License.
+;;
+;;
+
+(ns pigpen.functional.filter-test
+  (:use clojure.test)
+  (:require [pigpen.extensions.test :refer [test-diff]]
+            [pigpen.core :as pig]
+            [pigpen.fold :as fold]))
+
+(deftest test-filter
+  
+  (let [data (pig/return [1 2])
+        command (pig/filter odd? data)]
+    (test-diff
+      (pig/dump command)
+      '[1])))
+
+(deftest test-remove
+  
+  (let [data (pig/return [1 2])
+        command (pig/remove odd? data)]
+    (test-diff
+      (pig/dump command)
+      '[2])))

--- a/src/test/clojure/pigpen/functional/io_test.clj
+++ b/src/test/clojure/pigpen/functional/io_test.clj
@@ -1,0 +1,163 @@
+;;
+;;
+;;  Copyright 2013 Netflix, Inc.
+;;
+;;     Licensed under the Apache License, Version 2.0 (the "License");
+;;     you may not use this file except in compliance with the License.
+;;     You may obtain a copy of the License at
+;;
+;;         http://www.apache.org/licenses/LICENSE-2.0
+;;
+;;     Unless required by applicable law or agreed to in writing, software
+;;     distributed under the License is distributed on an "AS IS" BASIS,
+;;     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;;     See the License for the specific language governing permissions and
+;;     limitations under the License.
+;;
+;;
+
+(ns pigpen.functional.io-test
+  (:use clojure.test)
+  (:require [pigpen.extensions.test :refer [test-diff]]
+            [pigpen.core :as pig]
+            [pigpen.fold :as fold]))
+
+(.mkdirs (java.io.File. "build/functional/io-test"))
+
+(deftest test-load-pig
+  (let [command (pig/load-pig "build/functional/io-test/test-load-pig" [a b])]
+    (spit "build/functional/io-test/test-load-pig" "1\tfoo\n2\tbar\n")
+    (test-diff
+      (set (pig/dump command))
+      '#{{:a 2, :b "bar"}
+         {:a 1, :b "foo"}})))  
+
+(deftest test-load-string
+  (let [command (pig/load-string "build/functional/io-test/test-load-string")]
+    (spit "build/functional/io-test/test-load-string" "The quick brown fox\njumps over the lazy dog\n")
+    (test-diff
+      (set (pig/dump command))
+      '#{"The quick brown fox"
+         "jumps over the lazy dog"})))  
+
+(deftest test-load-tsv
+  
+  (testing "Normal tsv with default delimiter"
+    (let [command (pig/load-tsv "build/functional/io-test/test-load-tsv")]
+      (spit "build/functional/io-test/test-load-tsv" "a\tb\tc\n1\t2\t3\n")
+      (test-diff
+        (set (pig/dump command))
+        '#{["a" "b" "c"]
+           ["1" "2" "3"]})))
+  
+  (testing "Normal tsv with non-tab delimiter"
+    (let [command (pig/load-tsv "build/functional/io-test/test-load-tsv" #",")]
+      (spit "build/functional/io-test/test-load-tsv" "a\tb\tc\n1\t2\t3\n")
+      (test-diff
+        (set (pig/dump command))
+        '#{["a\tb\tc"]
+           ["1\t2\t3"]})))
+  
+  (testing "Non-tsv with non-tab delimiter"
+    (let [command (pig/load-tsv "build/functional/io-test/test-load-tsv" #",")]
+      (spit "build/functional/io-test/test-load-tsv" "a,b,c\n1,2,3\n")
+      (test-diff
+        (set (pig/dump command))
+        '#{["a" "b" "c"]
+           ["1" "2" "3"]}))))
+
+(deftest test-load-clj
+  (let [command (pig/load-clj "build/functional/io-test/test-load-clj")]
+    (spit "build/functional/io-test/test-load-clj" "{:a 1, :b \"foo\"}\n{:a 2, :b \"bar\"}")
+    (test-diff
+      (set (pig/dump command))
+      '#{{:a 2, :b "bar"}
+         {:a 1, :b "foo"}})))
+
+(deftest test-load-json
+  
+  (spit "build/functional/io-test/test-load-json" "{\"a\" 1, \"b\" \"foo\"}\n{\"a\" 2, \"b\" \"bar\"}")
+  
+  (testing "Default"
+    (let [command (pig/load-json "build/functional/io-test/test-load-json")]
+      (test-diff
+        (set (pig/dump command))
+        '#{{:a 2, :b "bar"}
+           {:a 1, :b "foo"}})))
+  
+  (testing "No options"
+    (let [command (pig/load-json "build/functional/io-test/test-load-json" {})]
+      (test-diff
+        (set (pig/dump command))
+        '#{{"a" 2, "b" "bar"}
+           {"a" 1, "b" "foo"}})))
+  
+  (testing "Two options"
+    (let [command (pig/load-json "build/functional/io-test/test-load-json"
+                                 {:key-fn keyword
+                                  :value-fn (fn [k v]
+                                              (case k
+                                                :a (* v v)
+                                                :b (count v)))})]
+      (test-diff
+        (set (pig/dump command))
+        '#{{:a 1, :b 3}
+           {:a 4, :b 3}}))))
+
+(deftest test-load-lazy
+  (let [command (pig/load-tsv "build/functional/io-test/test-load-lazy")]
+    (spit "build/functional/io-test/test-load-lazy" "a\tb\tc\n1\t2\t3\n")
+    (test-diff
+      (set (pig/dump command))
+      '#{("a" "b" "c")
+         ("1" "2" "3")})))
+
+(deftest test-store-pig
+  (let [data (pig/return [{:a 1, :b "foo"}
+                         {:a 2, :b "bar"}])
+        command (pig/store-pig "build/functional/io-test/test-store-pig" data)]
+    (is (empty? (pig/dump command)))
+    (is (= "[a#1,b#foo]\n[a#2,b#bar]\n"
+           (slurp "build/functional/io-test/test-store-pig")))))
+
+(deftest test-store-string
+  (let [data (pig/return ["The quick brown fox"
+                         "jumps over the lazy dog"
+                         42
+                         :foo])
+        command (pig/store-string "build/functional/io-test/test-store-string" data)]
+    (is (empty? (pig/dump command)))
+    (is (= "The quick brown fox\njumps over the lazy dog\n42\n:foo\n"
+           (slurp "build/functional/io-test/test-store-string")))))
+
+(deftest test-store-tsv
+  (let [data (pig/return [[1 "foo" :a]
+                         [2 "bar" :b]])
+        command (pig/store-tsv "build/functional/io-test/test-store-tsv" data)]
+    (is (empty? (pig/dump command)))
+    (is (= "1\tfoo\t:a\n2\tbar\t:b\n"
+           (slurp "build/functional/io-test/test-store-tsv")))))
+
+(deftest test-store-clj
+  (let [data (pig/return [{:a 1, :b "foo"}
+                         {:a 2, :b "bar"}])
+        command (pig/store-clj "build/functional/io-test/test-store-clj" data)]
+    (is (empty? (pig/dump command)))
+    (is (= "{:a 1, :b \"foo\"}\n{:a 2, :b \"bar\"}\n"
+           (slurp "build/functional/io-test/test-store-clj")))))
+
+(deftest test-store-json
+  (let [data (pig/return [{:a 1, :b "foo"}
+                         {:a 2, :b "bar"}])
+        command (pig/store-json "build/functional/io-test/test-store-json" data)]
+    (is (empty? (pig/dump command)))
+    (is (= "{\"a\":1,\"b\":\"foo\"}\n{\"a\":2,\"b\":\"bar\"}\n"
+           (slurp "build/functional/io-test/test-store-json")))))
+
+(deftest test-return
+  
+  (let [data [1 2]
+        command (pig/return data)]
+    (test-diff
+      (pig/dump command)
+      '[1 2])))

--- a/src/test/clojure/pigpen/functional/join_test.clj
+++ b/src/test/clojure/pigpen/functional/join_test.clj
@@ -1,0 +1,464 @@
+;;
+;;
+;;  Copyright 2013 Netflix, Inc.
+;;
+;;     Licensed under the Apache License, Version 2.0 (the "License");
+;;     you may not use this file except in compliance with the License.
+;;     You may obtain a copy of the License at
+;;
+;;         http://www.apache.org/licenses/LICENSE-2.0
+;;
+;;     Unless required by applicable law or agreed to in writing, software
+;;     distributed under the License is distributed on an "AS IS" BASIS,
+;;     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;;     See the License for the specific language governing permissions and
+;;     limitations under the License.
+;;
+;;
+
+(ns pigpen.functional.join-test
+  (:use clojure.test)
+  (:require [pigpen.extensions.test :refer [test-diff]]
+            [pigpen.core :as pig]
+            [pigpen.fold :as fold]))
+
+(deftest test-group-by
+  (let [data (pig/return [{:a 1 :b 2}
+                         {:a 1 :b 3}
+                         {:a 2 :b 4}])
+          
+        command (pig/group-by :a data)]
+
+    (test-diff
+      (set (pig/dump command))
+      '#{[1 ({:a 1, :b 2} {:a 1, :b 3})]
+         [2 ({:a 2, :b 4})]})))
+
+(deftest test-into
+  (let [data (pig/return [2 4 6])
+        command (pig/into [] data)]
+
+    (test-diff
+      (pig/dump command)
+      '[[2 4 6]])))
+
+(deftest test-reduce
+  (testing "conj"
+    (let [data (pig/return [2 4 6])
+          command (pig/reduce conj [] data)]
+
+      (test-diff
+        (pig/dump command)
+        '[[2 4 6]])))
+  
+  (testing "+"
+    (let [data (pig/return [2 4 6])
+          command (pig/reduce + data)]
+
+      (test-diff
+        (pig/dump command)
+        '[12]))))
+
+(deftest test-fold
+  (let [data (pig/return [{:k :foo, :v 1}
+                          {:k :foo, :v 2}
+                          {:k :foo, :v 3}
+                          {:k :bar, :v 4}
+                          {:k :bar, :v 5}])]
+    
+    (testing "inline sum"
+      (let [command (->> data
+                      (pig/group-by :k
+                        {:fold (fold/fold-fn +
+                                             (fn [acc value]
+                                               (+ acc (:v value))))}))]
+        (is (= (set (pig/dump command))
+               '#{[:foo 6]
+                  [:bar 9]}))))
+    
+    (testing "inline count"
+      (let [command (->> data
+                      (pig/group-by :k
+                        {:fold (fold/fold-fn (fn ([] 0)
+                                                 ([a b] (+ a b)))
+                                             (fn [acc _] (inc acc)))}))]
+        (is (= (set (pig/dump command))
+               '#{[:bar 2]
+                  [:foo 3]}))))
+    
+    (testing "using fold/count"
+      (let [command (->> data
+                      (pig/group-by :k
+                        {:fold (fold/count)}))]
+        (is (= (set (pig/dump command))
+               '#{[:bar 2]
+                  [:foo 3]})))))
+  
+  (testing "dual fold co-group"
+    (let [data0 (pig/return [{:k :foo, :a 1}
+                            {:k :foo, :a 2}
+                            {:k :foo, :a 3}
+                            {:k :bar, :a 4}
+                            {:k :bar, :a 5}])
+          data1 (pig/return [{:k :foo, :b 1}
+                            {:k :foo, :b 2}
+                            {:k :bar, :b 3}
+                            {:k :bar, :b 4}
+                            {:k :bar, :b 5}])
+          command (pig/cogroup [(data0 :on :k, :required true, :fold (->> (fold/map :a) (fold/sum)))
+                                (data1 :on :k, :required true, :fold (->> (fold/map :b) (fold/sum)))]
+                               vector)]
+      (is (= (set (pig/dump command))
+             '#{[:foo 6 3]
+                [:bar 9 12]}))))
+  
+  (testing "fold all sum" 
+    (let [data (pig/return [1 2 3 4])
+          command (pig/fold + data)]
+      (is (= (pig/dump command)
+             '[10]))))
+  
+  (testing "fold all count"
+    (let [data (pig/return [1 2 3 4])
+          command (pig/fold (fold/count) data)]
+     (is (= (pig/dump command)
+            '[4])))))
+
+(deftest test-cogroup
+  (let [data1 (pig/return [{:k nil, :v 1}
+                          {:k nil, :v 3}
+                          {:k :i, :v 5}
+                          {:k :i, :v 7}
+                          {:k :l, :v 9}
+                          {:k :l, :v 11}])
+        data2 (pig/return [{:k nil, :v 2}
+                          {:k nil, :v 4}
+                          {:k :i, :v 6}
+                          {:k :i, :v 8}
+                          {:k :r, :v 10}
+                          {:k :r, :v 12}])]
+
+    (testing "inner"
+      (test-diff
+        (set (pig/dump (pig/cogroup [(data1 :by :k :type :required)
+                                     (data2 :by :k :type :required)]
+                                    vector)))
+        '#{[:i [{:k :i, :v 5} {:k :i, :v 7}] [{:k :i, :v 6} {:k :i, :v 8}]]}))
+
+    (testing "left outer"
+      (test-diff
+        (set (pig/dump (pig/cogroup [(data1 :on :k :type :required)
+                                     (data2 :on :k :type :optional)]
+                                    vector)))
+        '#{[nil [{:k nil, :v 1} {:k nil, :v 3}] nil]
+           [:i  [{:k :i, :v 5} {:k :i, :v 7}]   [{:k :i, :v 6} {:k :i, :v 8}]]
+           [:l  [{:k :l, :v 9} {:k :l, :v 11}]  nil]}))
+    
+    (testing "right outer"
+      (test-diff
+        (set (pig/dump (pig/cogroup [(data1 :on :k :type :optional)
+                                     (data2 :on :k :type :required)]
+                                    vector)))
+        '#{[nil nil                           [{:k nil, :v 2} {:k nil, :v 4}]]
+           [:i  [{:k :i, :v 5} {:k :i, :v 7}] [{:k :i, :v 6} {:k :i, :v 8}]]
+           [:r  nil                           [{:k :r, :v 10} {:k :r, :v 12}]]}))
+    
+    (testing "full outer"
+      (test-diff
+        (set (pig/dump (pig/cogroup [(data1 :on :k :type :optional)
+                                     (data2 :on :k :type :optional)]
+                                    vector)))
+        '#{[nil [{:k nil, :v 1} {:k nil, :v 3}] nil]
+           [nil nil                             [{:k nil, :v 2} {:k nil, :v 4}]]
+           [:i  [{:k :i, :v 5} {:k :i, :v 7}]   [{:k :i, :v 6} {:k :i, :v 8}]]
+           [:l  [{:k :l, :v 9} {:k :l, :v 11}]  nil]
+           [:r  nil                             [{:k :r, :v 10} {:k :r, :v 12}]]}))
+    
+    (testing "inner join nils"
+      (test-diff
+        (set (pig/dump (pig/cogroup [(data1 :on :k :type :required)
+                                     (data2 :on :k :type :required)]
+                                    vector
+                                    {:join-nils true})))
+        '#{[nil [{:k nil, :v 1} {:k nil, :v 3}] [{:k nil, :v 2} {:k nil, :v 4}]]
+           [:i  [{:k :i, :v 5} {:k :i, :v 7}]   [{:k :i, :v 6} {:k :i, :v 8}]]}))
+    
+    (testing "left outer join nils"
+      (test-diff
+        (set (pig/dump (pig/cogroup [(data1 :on :k :type :required)
+                                     (data2 :on :k :type :optional)]
+                                    vector
+                                    {:join-nils true})))
+        '#{[nil [{:k nil, :v 1} {:k nil, :v 3}] [{:k nil, :v 2} {:k nil, :v 4}]]
+           [:i  [{:k :i, :v 5} {:k :i, :v 7}]   [{:k :i, :v 6} {:k :i, :v 8}]]
+           [:l  [{:k :l, :v 9} {:k :l, :v 11}]  nil]}))
+    
+    (testing "right outer join nils"
+      (test-diff
+        (set (pig/dump (pig/cogroup [(data1 :on :k :type :optional)
+                                     (data2 :on :k :type :required)]
+                                    vector
+                                    {:join-nils true})))
+        '#{[nil [{:k nil, :v 1} {:k nil, :v 3}] [{:k nil, :v 2} {:k nil, :v 4}]]
+           [:i  [{:k :i, :v 5} {:k :i, :v 7}]   [{:k :i, :v 6} {:k :i, :v 8}]]
+           [:r  nil                             [{:k :r, :v 10} {:k :r, :v 12}]]}))
+    
+    (testing "full outer join nils"
+      (test-diff
+        (set (pig/dump (pig/cogroup [(data1 :on :k :type :optional)
+                                     (data2 :on :k :type :optional)]
+                                    vector
+                                    {:join-nils true})))
+        '#{[nil [{:k nil, :v 1} {:k nil, :v 3}] [{:k nil, :v 2} {:k nil, :v 4}]]
+           [:i  [{:k :i, :v 5} {:k :i, :v 7}]   [{:k :i, :v 6} {:k :i, :v 8}]]
+           [:l  [{:k :l, :v 9} {:k :l, :v 11}]  nil]
+           [:r  nil                             [{:k :r, :v 10} {:k :r, :v 12}]]}))
+    
+    (testing "self cogroup"
+      (let [data (pig/return [0 1 2])
+          command (pig/cogroup [(data)
+                                (data)]
+                               vector)]
+        (is (= (pig/dump command)
+               '[[2 (2) (2)] [0 (0) (0)] [1 (1) (1)]]))))
+    
+    (testing "self cogroup with fold"
+      (let [data (pig/return [0 1 2])
+          command (pig/cogroup [(data :fold (fold/count))
+                                (data :fold (fold/count))]
+                               vector)]
+        (is (= (pig/dump command)
+               '[[2 1 1] [0 1 1] [1 1 1]]))))))
+
+(deftest test-join
+  (let [data1 (pig/return [{:k nil, :v 1}
+                          {:k nil, :v 3}
+                          {:k :i, :v 5}
+                          {:k :i, :v 7}
+                          {:k :l, :v 9}
+                          {:k :l, :v 11}])
+        data2 (pig/return [{:k nil, :v 2}
+                          {:k nil, :v 4}
+                          {:k :i, :v 6}
+                          {:k :i, :v 8}
+                          {:k :r, :v 10}
+                          {:k :r, :v 12}])]
+
+    (testing "inner join - implicit :required" 
+      (test-diff
+        (set (pig/dump (pig/join [(data1 :on :k)
+                                  (data2 :on :k)]
+                                 vector)))
+        '#{[{:k :i, :v 5} {:k :i, :v 6}]
+           [{:k :i, :v 5} {:k :i, :v 8}]
+           [{:k :i, :v 7} {:k :i, :v 6}]
+           [{:k :i, :v 7} {:k :i, :v 8}]})) 
+  
+    (testing "inner"
+      (test-diff
+        (set (pig/dump (pig/join [(data1 :on :k :type :required)
+                                  (data2 :on :k :type :required)]
+                                 vector)))
+        '#{[{:k :i, :v 5} {:k :i, :v 6}]
+           [{:k :i, :v 5} {:k :i, :v 8}]
+           [{:k :i, :v 7} {:k :i, :v 6}]
+           [{:k :i, :v 7} {:k :i, :v 8}]}))
+    
+    (testing "left outer"
+      (test-diff
+        (set (pig/dump (pig/join [(data1 :on :k :type :required)
+                                  (data2 :on :k :type :optional)]
+                                 vector)))
+        '#{[{:k nil, :v 1} nil]
+           [{:k nil, :v 3} nil]
+           [{:k :i, :v 5} {:k :i, :v 6}]
+           [{:k :i, :v 5} {:k :i, :v 8}]
+           [{:k :i, :v 7} {:k :i, :v 6}]
+           [{:k :i, :v 7} {:k :i, :v 8}]
+           [{:k :l, :v 9} nil]
+           [{:k :l, :v 11} nil]}))
+    
+    (testing "right outer"
+      (test-diff
+        (set (pig/dump (pig/join [(data1 :on :k :type :optional)
+                                  (data2 :on :k :type :required)]
+                                 vector)))
+        '#{[nil {:k nil, :v 2}]
+           [nil {:k nil, :v 4}]
+           [{:k :i, :v 5} {:k :i, :v 6}]
+           [{:k :i, :v 5} {:k :i, :v 8}]
+           [{:k :i, :v 7} {:k :i, :v 6}]
+           [{:k :i, :v 7} {:k :i, :v 8}]
+           [nil {:k :r, :v 10}]
+           [nil {:k :r, :v 12}]}))
+    
+    (testing "full outer"
+      (test-diff
+        (set (pig/dump (pig/join [(data1 :on :k :type :optional)
+                                  (data2 :on :k :type :optional)]
+                                 vector)))
+        '#{[{:k nil, :v 1} nil]
+           [{:k nil, :v 3} nil]
+           [nil {:k nil, :v 2}]
+           [nil {:k nil, :v 4}]
+           [{:k :i, :v 5} {:k :i, :v 6}]
+           [{:k :i, :v 5} {:k :i, :v 8}]
+           [{:k :i, :v 7} {:k :i, :v 6}]
+           [{:k :i, :v 7} {:k :i, :v 8}]
+           [{:k :l, :v 9} nil]
+           [{:k :l, :v 11} nil]
+           [nil {:k :r, :v 10}]
+           [nil {:k :r, :v 12}]}))
+    
+    (testing "inner join nils"
+      (test-diff
+        (set (pig/dump (pig/join [(data1 :on :k :type :required)
+                                  (data2 :on :k :type :required)]
+                                 vector
+                                 {:join-nils true})))
+        '#{[{:k nil, :v 1} {:k nil, :v 2}]
+           [{:k nil, :v 3} {:k nil, :v 2}]
+           [{:k nil, :v 1} {:k nil, :v 4}]
+           [{:k nil, :v 3} {:k nil, :v 4}]
+           [{:k :i, :v 5} {:k :i, :v 6}]
+           [{:k :i, :v 5} {:k :i, :v 8}]
+           [{:k :i, :v 7} {:k :i, :v 6}]
+           [{:k :i, :v 7} {:k :i, :v 8}]}))
+    
+    (testing "left outer join nils"
+      (test-diff
+        (set (pig/dump (pig/join [(data1 :on :k :type :required)
+                                  (data2 :on :k :type :optional)]
+                                 vector
+                                 {:join-nils true})))
+        '#{[{:k nil, :v 1} {:k nil, :v 2}]
+           [{:k nil, :v 3} {:k nil, :v 2}]
+           [{:k nil, :v 1} {:k nil, :v 4}]
+           [{:k nil, :v 3} {:k nil, :v 4}]
+           [{:k :i, :v 5} {:k :i, :v 6}]
+           [{:k :i, :v 5} {:k :i, :v 8}]
+           [{:k :i, :v 7} {:k :i, :v 6}]
+           [{:k :i, :v 7} {:k :i, :v 8}]
+           [{:k :l, :v 9} nil]
+           [{:k :l, :v 11} nil]}))
+    
+    (testing "right outer join nils"
+      (test-diff
+        (set (pig/dump (pig/join [(data1 :on :k :type :optional)
+                                  (data2 :on :k :type :required)]
+                                 vector
+                                 {:join-nils true})))
+        '#{[{:k nil, :v 1} {:k nil, :v 2}]
+           [{:k nil, :v 3} {:k nil, :v 2}]
+           [{:k nil, :v 1} {:k nil, :v 4}]
+           [{:k nil, :v 3} {:k nil, :v 4}]
+           [{:k :i, :v 5} {:k :i, :v 6}]
+           [{:k :i, :v 5} {:k :i, :v 8}]
+           [{:k :i, :v 7} {:k :i, :v 6}]
+           [{:k :i, :v 7} {:k :i, :v 8}]
+           [nil {:k :r, :v 10}]
+           [nil {:k :r, :v 12}]}))
+    
+    (testing "full outer join nils"
+      (test-diff
+        (set (pig/dump (pig/join [(data1 :on :k :type :optional)
+                                  (data2 :on :k :type :optional)]
+                                 vector
+                                 {:join-nils true})))
+        '#{[{:k nil, :v 1} {:k nil, :v 2}]
+           [{:k nil, :v 3} {:k nil, :v 2}]
+           [{:k nil, :v 1} {:k nil, :v 4}]
+           [{:k nil, :v 3} {:k nil, :v 4}]
+           [{:k :i, :v 5} {:k :i, :v 6}]
+           [{:k :i, :v 5} {:k :i, :v 8}]
+           [{:k :i, :v 7} {:k :i, :v 6}]
+           [{:k :i, :v 7} {:k :i, :v 8}]
+           [{:k :l, :v 9} nil]
+           [{:k :l, :v 11} nil]
+           [nil {:k :r, :v 10}]
+           [nil {:k :r, :v 12}]}))
+      
+  (testing "self join"
+    (let [data (pig/return [0 1 2])
+          command (pig/join [(data)
+                                  (data)]
+                                 vector)]
+      (is (= (pig/dump command)
+             [[2 2] [0 0] [1 1]]))))
+  
+  (testing "key-selector defaults to identity"
+    (let [data1 (pig/return [1 2])
+          data2 (pig/return [2 3])
+          
+          command (pig/join [(data1)
+                             (data2)]
+                            vector)]
+      (test-diff
+        (set (pig/dump command))
+        '#{[2 2]})))))
+
+(deftest test-filter-by
+  (let [data (pig/return [{:k nil, :v 1}
+                         {:k nil, :v 3}
+                         {:k :i, :v 5}
+                         {:k :i, :v 7}
+                         {:k :l, :v 9}
+                         {:k :l, :v 11}])]
+
+    (testing "Normal"
+      (let [keys (pig/return [:i])]
+        (test-diff
+          (set (pig/dump (pig/filter-by :k keys data)))
+          '#{{:k :i, :v 5}
+             {:k :i, :v 7}})))
+    
+    (testing "Nil keys"
+      (let [keys (pig/return [:i nil])]
+        (test-diff
+          (set (pig/dump (pig/filter-by :k keys data)))
+          '#{{:k nil, :v 1}
+             {:k nil, :v 3}
+             {:k :i, :v 5}
+             {:k :i, :v 7}})))
+    
+    (testing "Duplicate keys"
+      (let [keys (pig/return [:i :i])]
+        (test-diff
+          (pig/dump (pig/filter-by :k keys data))
+          '[{:k :i, :v 5}
+            {:k :i, :v 7}
+            {:k :i, :v 5}
+            {:k :i, :v 7}])))))
+
+(deftest test-remove-by
+  (let [data (pig/return [{:k nil, :v 1}
+                         {:k nil, :v 3}
+                         {:k :i, :v 5}
+                         {:k :i, :v 7}
+                         {:k :l, :v 9}
+                         {:k :l, :v 11}])]
+
+    (testing "Normal"
+      (let [keys (pig/return [:i])]
+          (test-diff
+            (set (pig/dump (pig/remove-by :k keys data)))
+            '#{{:k nil, :v 1}
+               {:k nil, :v 3}
+               {:k :l, :v 9}
+               {:k :l, :v 11}})))
+    
+    (testing "Nil keys"
+      (let [keys (pig/return [:i nil])]
+        (test-diff
+          (set (pig/dump (pig/remove-by :k keys data)))
+          '#{{:k :l, :v 9}
+             {:k :l, :v 11}})))
+    
+    (testing "Duplicate keys"
+      (let [keys (pig/return [:i :i])]
+        (test-diff
+          (set (pig/dump (pig/remove-by :k keys data)))
+          '#{{:k nil, :v 1}
+             {:k nil, :v 3}
+             {:k :l, :v 9}
+             {:k :l, :v 11}})))))

--- a/src/test/clojure/pigpen/functional/map_test.clj
+++ b/src/test/clojure/pigpen/functional/map_test.clj
@@ -1,0 +1,104 @@
+;;
+;;
+;;  Copyright 2013 Netflix, Inc.
+;;
+;;     Licensed under the Apache License, Version 2.0 (the "License");
+;;     you may not use this file except in compliance with the License.
+;;     You may obtain a copy of the License at
+;;
+;;         http://www.apache.org/licenses/LICENSE-2.0
+;;
+;;     Unless required by applicable law or agreed to in writing, software
+;;     distributed under the License is distributed on an "AS IS" BASIS,
+;;     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;;     See the License for the specific language governing permissions and
+;;     limitations under the License.
+;;
+;;
+
+(ns pigpen.functional.map-test
+  (:use clojure.test)
+  (:require [pigpen.extensions.test :refer [test-diff]]
+            [pigpen.core :as pig]
+            [pigpen.fold :as fold]))
+
+(deftest test-map
+  
+  (let [data (pig/return [{:x 1, :y 2}
+                         {:x 2, :y 4}])
+        command (pig/map (fn [{:keys [x y]}] (+ x y)) data)]
+    (test-diff
+      (pig/dump command)
+      '[3 6])))
+  
+(deftest test-mapcat
+  
+  (let [data (pig/return [{:x 1, :y 2}
+                         {:x 2, :y 4}])
+        command (pig/mapcat (juxt :x :y) data)]
+    (test-diff
+      (pig/dump command)
+      '[1 2 2 4])))
+
+(deftest test-map-indexed
+  
+  (let [data (pig/return [{:a 2} {:a 1} {:a 3}])
+        command (pig/map-indexed vector data)]
+    (test-diff
+      (pig/dump command)
+      '[[0 {:a 2}] [1 {:a 1}] [2 {:a 3}]]))
+  
+  (let [command (->>
+                  (pig/return [{:a 2} {:a 1} {:a 3}])
+                  (pig/sort-by :a)
+                  (pig/map-indexed vector))]
+    (test-diff
+      (pig/dump command)
+      '[[0 {:a 1}] [1 {:a 2}] [2 {:a 3}]])))
+
+(deftest test-sort
+  
+  (let [data (pig/return [2 1 4 3])
+        command (pig/sort data)]
+    (test-diff
+      (pig/dump command)
+      '[1 2 3 4]))
+  
+  (let [data (pig/return [2 1 4 3])
+        command (pig/sort :desc data)]
+    (test-diff
+      (pig/dump command)
+      '[4 3 2 1])))
+
+(deftest test-sort-by
+  
+  (let [data (pig/return [{:a 2} {:a 1} {:a 3}])
+        command (pig/sort-by :a data)]
+    (test-diff
+      (pig/dump command)
+      '[{:a 1} {:a 2} {:a 3}]))
+  
+  (let [data (pig/return [{:a 2} {:a 1} {:a 3}])
+       command (pig/sort-by :a :desc data)]
+   (test-diff
+     (pig/dump command)
+     '[{:a 3} {:a 2} {:a 1}]))
+  
+  (let [data (pig/return [1 2 3 1 2 3 1 2 3])
+        command (pig/sort-by identity data)]
+    (is (= (pig/dump command)
+           [1 1 1 2 2 2 3 3 3]))))
+
+(deftest test-map+fold
+  (is (= (pig/dump
+           (->> (pig/return [-2 -1 0 1 2])
+             (pig/map #(> % 0))
+             (pig/fold (->> (fold/filter identity) (fold/count)))))
+         [2])))
+
+(deftest test-map+reduce
+  (is (= (pig/dump
+           (->> (pig/return [-2 -1 0 1 2])
+             (pig/map inc)
+             (pig/fold (->> (fold/filter #(> % 0)) (fold/count)))))
+         [3])))

--- a/src/test/clojure/pigpen/functional/set_test.clj
+++ b/src/test/clojure/pigpen/functional/set_test.clj
@@ -1,0 +1,85 @@
+;;
+;;
+;;  Copyright 2013 Netflix, Inc.
+;;
+;;     Licensed under the Apache License, Version 2.0 (the "License");
+;;     you may not use this file except in compliance with the License.
+;;     You may obtain a copy of the License at
+;;
+;;         http://www.apache.org/licenses/LICENSE-2.0
+;;
+;;     Unless required by applicable law or agreed to in writing, software
+;;     distributed under the License is distributed on an "AS IS" BASIS,
+;;     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;;     See the License for the specific language governing permissions and
+;;     limitations under the License.
+;;
+;;
+
+(ns pigpen.functional.set-test
+  (:use clojure.test)
+  (:require [pigpen.extensions.test :refer [test-diff]]
+            [pigpen.core :as pig]
+            [pigpen.fold :as fold]))
+
+(deftest test-union
+  (let [data1 (pig/return [1 2 3])
+        data2 (pig/return [2 3 4])
+        data3 (pig/return [3 4 5])
+        
+        command (pig/union data1 data2 data3)]
+    (test-diff
+      (set (pig/dump command))
+      '#{1 2 3 4 5})))
+
+(deftest test-union-multiset
+  (let [data1 (pig/return [1 2 3])
+        data2 (pig/return [2 3 4])
+        data3 (pig/return [3 4 5])
+        
+        command (pig/union-multiset data1 data2 data3)]
+    (test-diff
+      (sort (pig/dump command))
+      '[1 2 2
+        3 3 3
+        4 4 5])))
+
+(deftest test-intersection
+  (let [data1 (pig/return [1 2 3 3])
+        data2 (pig/return [3 2 3 4 3])
+        data3 (pig/return [3 4 3 5 2])
+        
+        command (pig/intersection data1 data2 data3)]
+    (test-diff
+      (sort (pig/dump command))
+      '[2 3])))
+
+(deftest test-intersection-multiset
+  (let [data1 (pig/return [1 2 3 3])
+        data2 (pig/return [3 2 3 4 3])
+        data3 (pig/return [3 4 3 5 2])
+        
+        command (pig/intersection-multiset data1 data2 data3)]
+    (test-diff
+      (sort (pig/dump command))
+      '[2 3 3])))
+
+(deftest test-difference
+  (let [data1 (pig/return [1 2 3 3 3 4 5])
+        data2 (pig/return [1 2])
+        data3 (pig/return [4 5])
+        
+        command (pig/difference data1 data2 data3)]
+    (test-diff
+      (sort (pig/dump command))
+      '[3])))
+
+(deftest test-difference-multiset
+  (let [data1 (pig/return [1 2 3 3 3 4 5])
+        data2 (pig/return [1 2 3])
+        data3 (pig/return [3 4 5])
+        
+        command (pig/difference-multiset data1 data2 data3)]
+    (test-diff
+      (sort (pig/dump command))
+      '[3])))

--- a/src/test/clojure/pigpen/local_test.clj
+++ b/src/test/clojure/pigpen/local_test.clj
@@ -18,23 +18,24 @@
 
 (ns pigpen.local-test
   (:use clojure.test)
-  (:require [pigpen.extensions.test :refer [test-diff pigsym-zero pigsym-inc]]
+  (:require [pigpen.extensions.test :refer [test-diff pigsym-inc]]
             [pigpen.local :as local]
             [pigpen.pig :refer [freeze-vals thaw-anything]]
             [pigpen.raw :as raw]
+            [pigpen.core :as pig]
             [pigpen.io :as io]
-            [pigpen.map :as pig-map]
-            [pigpen.filter :as pig-filter]
-            [pigpen.set :as pig-set]
-            [pigpen.join :as pig-join]
-            [pigpen.exec :as exec]
-            [pigpen.fold :as fold]
-            [taoensso.nippy :refer [freeze thaw]])
-  (:import [rx Observable]
-           [rx.observables BlockingObservable]
-           [org.apache.pig.data DataByteArray DataBag]))
+            [pigpen.exec :as exec])
+  (:import [org.apache.pig.data DataBag]))
 
 (.mkdirs (java.io.File. "build/local-test"))
+
+(defn debug-script-raw [query]
+  (->> query
+    exec/query->observable
+    local/observable->raw-data))
+
+(defn debug-script [query]
+  (map 'value (debug-script-raw query)))
 
 (deftest test-eval-code
   
@@ -101,10 +102,10 @@
 (deftest test-debug
   (with-redefs [pigpen.raw/pigsym (pigsym-inc)]
     (let [command (->>
-                    (io/load-clj "build/local-test/test-debug-in")
-                    (pig-filter/filter (comp odd? :a))
-                    (pig-map/map :b)
-                    (io/store-clj "build/local-test/test-debug-out"))]
+                    (pig/load-clj "build/local-test/test-debug-in")
+                    (pig/filter (comp odd? :a))
+                    (pig/map :b)
+                    (pig/store-clj "build/local-test/test-debug-out"))]
       (spit "build/local-test/test-debug-in" "{:a 1, :b \"foo\"}\n{:a 2, :b \"bar\"}")
       #_(exec/write-script "build/local-test/temp.pig" {:debug "build/local-test/"} command)
       (is (empty? (exec/dump {:debug "build/local-test/test-debug-"} command)))
@@ -125,306 +126,49 @@
   (let [command (raw/load$ "build/local-test/test-load" '[a b c] raw/default-storage {:cast "chararray"})]
     (spit "build/local-test/test-load" "a\tb\tc\n1\t2\t3\n")
     (test-diff
-      (exec/debug-script-raw command)
+      (debug-script-raw command)
       '[{a "a", b "b", c "c"}
         {a "1", b "2", c "3"}])))
-
-(deftest test-load-pig
-  (let [command (io/load-pig "build/local-test/test-load-pig" [a b])]
-    (spit "build/local-test/test-load-pig" "1\tfoo\n2\tbar\n")
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze {:a 2, :b "bar"})
-         (freeze {:a 1, :b "foo"})})))  
-
-(deftest test-load-string
-  (let [command (io/load-string "build/local-test/test-load-string")]
-    (spit "build/local-test/test-load-string" "The quick brown fox\njumps over the lazy dog\n")
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze "The quick brown fox")
-         (freeze "jumps over the lazy dog")})))  
-
-(deftest test-load-tsv
-  
-  (testing "Normal tsv with default delimiter"
-    (let [command (io/load-tsv "build/local-test/test-load-tsv")]
-      (spit "build/local-test/test-load-tsv" "a\tb\tc\n1\t2\t3\n")
-      (test-diff
-        (set (exec/debug-script command))
-        '#{(freeze ["a" "b" "c"])
-           (freeze ["1" "2" "3"])})))
-  
-  (testing "Normal tsv with non-tab delimiter"
-    (let [command (io/load-tsv "build/local-test/test-load-tsv" #",")]
-      (spit "build/local-test/test-load-tsv" "a\tb\tc\n1\t2\t3\n")
-      (test-diff
-        (set (exec/debug-script command))
-        '#{(freeze ["a\tb\tc"])
-           (freeze ["1\t2\t3"])})))
-  
-  (testing "Non-tsv with non-tab delimiter"
-    (let [command (io/load-tsv "build/local-test/test-load-tsv" #",")]
-      (spit "build/local-test/test-load-tsv" "a,b,c\n1,2,3\n")
-      (test-diff
-        (set (exec/debug-script command))
-        '#{(freeze ["a" "b" "c"])
-           (freeze ["1" "2" "3"])}))))
-
-(deftest test-load-clj
-  (let [command (io/load-clj "build/local-test/test-load-clj")]
-    (spit "build/local-test/test-load-clj" "{:a 1, :b \"foo\"}\n{:a 2, :b \"bar\"}")
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze {:a 2, :b "bar"})
-         (freeze {:a 1, :b "foo"})})))
-
-(deftest test-load-json
-  
-  (spit "build/local-test/test-load-json" "{\"a\" 1, \"b\" \"foo\"}\n{\"a\" 2, \"b\" \"bar\"}")
-  
-  (testing "Default"
-    (let [command (io/load-json "build/local-test/test-load-json")]
-      (test-diff
-        (set (exec/debug-script command))
-        '#{(freeze {:a 2, :b "bar"})
-           (freeze {:a 1, :b "foo"})})))
-  
-  (testing "No options"
-    (let [command (io/load-json "build/local-test/test-load-json" {})]
-      (test-diff
-        (set (exec/debug-script command))
-        '#{(freeze {"a" 2, "b" "bar"})
-           (freeze {"a" 1, "b" "foo"})})))
-  
-  (testing "Two options"
-    (let [command (io/load-json "build/local-test/test-load-json"
-                                {:key-fn keyword
-                                 :value-fn (fn [k v]
-                                             (case k
-                                               :a (* v v)
-                                               :b (count v)))})]
-      (test-diff
-        (set (exec/debug-script command))
-        '#{(freeze {:a 1, :b 3})
-           (freeze {:a 4, :b 3})}))))
-
-(deftest test-load-lazy
-  (let [command (io/load-tsv "build/local-test/test-load-lazy")]
-    (spit "build/local-test/test-load-lazy" "a\tb\tc\n1\t2\t3\n")
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze ("a" "b" "c"))
-         (freeze ("1" "2" "3"))})))
 
 (deftest test-store
   (let [data (io/return-raw '[{a "a", b "b", c "c"}
                               {a "1", b "2", c "3"}])
         command (raw/store$ data "build/local-test/test-store" raw/default-storage {})]
-    (is (empty? (exec/debug-script command)))
+    (is (empty? (debug-script command)))
     (is (= "a\tb\tc\n1\t2\t3\n"
            (slurp "build/local-test/test-store")))))
 
-(deftest test-store-pig
-  (let [data (io/return [{:a 1, :b "foo"}
-                         {:a 2, :b "bar"}])
-        command (io/store-pig "build/local-test/test-store-pig" data)]
-    (is (empty? (exec/debug-script command)))
-    (is (= "[a#1,b#foo]\n[a#2,b#bar]\n"
-           (slurp "build/local-test/test-store-pig")))))
-
-(deftest test-store-string
-  (let [data (io/return ["The quick brown fox"
-                         "jumps over the lazy dog"
-                         42
-                         :foo])
-        command (io/store-string "build/local-test/test-store-string" data)]
-    (is (empty? (exec/debug-script command)))
-    (is (= "The quick brown fox\njumps over the lazy dog\n42\n:foo\n"
-           (slurp "build/local-test/test-store-string")))))
-
-(deftest test-store-tsv
-  (let [data (io/return [[1 "foo" :a]
-                         [2 "bar" :b]])
-        command (io/store-tsv "build/local-test/test-store-tsv" data)]
-    (is (empty? (exec/debug-script command)))
-    (is (= "1\tfoo\t:a\n2\tbar\t:b\n"
-           (slurp "build/local-test/test-store-tsv")))))
-
-(deftest test-store-clj
-  (let [data (io/return [{:a 1, :b "foo"}
-                         {:a 2, :b "bar"}])
-        command (io/store-clj "build/local-test/test-store-clj" data)]
-    (is (empty? (exec/debug-script command)))
-    (is (= "{:a 1, :b \"foo\"}\n{:a 2, :b \"bar\"}\n"
-           (slurp "build/local-test/test-store-clj")))))
-
-(deftest test-store-json
-  (let [data (io/return [{:a 1, :b "foo"}
-                         {:a 2, :b "bar"}])
-        command (io/store-json "build/local-test/test-store-json" data)]
-    (is (empty? (exec/debug-script command)))
-    (is (= "{\"a\":1,\"b\":\"foo\"}\n{\"a\":2,\"b\":\"bar\"}\n"
-           (slurp "build/local-test/test-store-json")))))
-
-(deftest test-return
-  
-  (let [data [1 2]
-        command (io/return data)]
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze 1) (freeze 2)])))
-
 ;; ********** Map **********
 
-(deftest test-map
-  
-  (let [data (io/return [{:x 1, :y 2}
-                         {:x 2, :y 4}])
-        command (pig-map/map (fn [{:keys [x y]}] (+ x y)) data)]
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze 3) (freeze 6)]))
-  
+(deftest test-exception-handling
   (let [data (io/return [1 2 3])
-        command (pig-map/map (fn [x] (throw (java.lang.Exception.))) data)]
-    (is (thrown? Exception (exec/debug-script command)))))
-
-(defn test-fn [x]
-  (* x x))
-
-(defn test-param [y data]
-  (let [z 42]
-    (->> data
-      (pig-map/map (fn [x] (+ (test-fn x) y z))))))
-
-(deftest test-closure
-  (let [data (io/return [1 2 3])
-        command (test-param 37 data)]
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze 80) (freeze 83) (freeze 88)])))
-
-(deftest test-mapcat
-  
-  (let [data (io/return [{:x 1, :y 2}
-                         {:x 2, :y 4}])
-        command (pig-map/mapcat (juxt :x :y) data)]
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze 1)
-        (freeze 2)
-        (freeze 2)
-        (freeze 4)])))
-
-(deftest test-map-indexed
-  
-  (let [data (io/return [{:a 2} {:a 1} {:a 3}])
-        command (pig-map/map-indexed vector data)]
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze [0 {:a 2}]) (freeze [1 {:a 1}]) (freeze [2 {:a 3}])]))
-  
-  (let [command (->>
-                  (io/return [{:a 2} {:a 1} {:a 3}])
-                  (pig-map/sort-by :a)
-                  (pig-map/map-indexed vector))]
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze [0 {:a 1}]) (freeze [1 {:a 2}]) (freeze [2 {:a 3}])])))
+        command (pig/map (fn [x] (throw (java.lang.Exception.))) data)]
+    (is (thrown? Exception (exec/dump command)))))
 
 (deftest test-pig-compare
   (is (= -1 (#'pigpen.local/pig-compare ['key :asc] '{key 1} '{key 2})))
   (is (= 1 (#'pigpen.local/pig-compare ['key :desc] '{key 1} '{key 2})))
   (is (= -1 (#'pigpen.local/pig-compare ['key :desc 'value :asc] '{key 1 value 1} '{key 1 value 2}))))
 
-(deftest test-sort
-  
-  (let [data (io/return [2 1 4 3])
-        command (pig-map/sort data)]
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze 1) (freeze 2) (freeze 3) (freeze 4)]))
-  
-  (let [data (io/return [2 1 4 3])
-        command (pig-map/sort :desc data)]
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze 4) (freeze 3) (freeze 2) (freeze 1)])))
-
-(deftest test-sort-by
-  
-  (let [data (io/return [{:a 2} {:a 1} {:a 3}])
-        command (pig-map/sort-by :a data)]
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze {:a 1}) (freeze {:a 2}) (freeze {:a 3})]))
-  
-  (let [data (io/return [{:a 2} {:a 1} {:a 3}])
-       command (pig-map/sort-by :a :desc data)]
-   (test-diff
-     (exec/debug-script command)
-     '[(freeze {:a 3}) (freeze {:a 2}) (freeze {:a 1})]))
-  
-  (let [data (io/return [1 2 3 1 2 3 1 2 3])
-        command (pig-map/sort-by identity data)]
-    (is (= (exec/dump command)
-           [1 1 1 2 2 2 3 3 3]))))
-
-(deftest test-for
-  (is (= (pigpen.exec/dump
-           (apply pig-set/concat
-             (for [x [1 2 3]]
-               (->>
-                 (io/return [1 2 3])
-                 (pig-map/map (fn [y] (+ x y)))))))
-         [4 3 2 5 4 3 6 5 4])))
-
-(deftest test-map+fold
-  (is (= (pigpen.exec/dump
-           (->> (io/return [-2 -1 0 1 2])
-             (pig-map/map #(> % 0))
-             (pig-join/fold (->> (fold/filter identity) (fold/count)))))
-         [2])))
-
-(deftest test-map+reduce
-  (is (= (pigpen.exec/dump
-           (->> (io/return [-2 -1 0 1 2])
-             (pig-map/map inc)
-             (pig-join/fold (->> (fold/filter #(> % 0)) (fold/count)))))
-         [3])))
-
 ;; ********** Filter **********
-
-(deftest test-filter
-  
-  (let [data (io/return [1 2])
-        command (pig-filter/filter odd? data)]
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze 1)])))
 
 (deftest test-filter-native
   
   (let [data (io/return-raw '[{foo 1, bar 3}
-                              {foo 2, bar 1}])
-        command (raw/filter-native$ data '(and (= foo 1) (> bar 2)) {:fields '[foo bar]})
-        command' (raw/filter-native$ data nil {:fields '[foo bar]})]
-    (test-diff
-      (exec/debug-script-raw command)
-      '[{foo 1, bar 3}])
-    (test-diff
-      (exec/debug-script-raw command')
-      '[{foo 1, bar 3}
-        {foo 2, bar 1}])))
+                              {foo 2, bar 1}])]
+    
+    (testing "with filter"
+      (let [command (raw/filter-native$ data '(and (= foo 1) (> bar 2)) {:fields '[foo bar]})]
+        (test-diff
+          (debug-script-raw command)
+          '[{foo 1, bar 3}])))  
 
-(deftest test-remove
-  
-  (let [data (io/return [1 2])
-        command (pig-filter/remove odd? data)]
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze 2)])))
+    (testing "no filter"
+      (let [command' (raw/filter-native$ data nil {:fields '[foo bar]})]
+        (test-diff
+          (debug-script-raw command')
+          '[{foo 1, bar 3}
+            {foo 2, bar 1}])))))
 
 (deftest test-limit
   
@@ -433,7 +177,7 @@
                                   {x 2, y 4}]))
         command (raw/limit$ data 1 {})]
     (test-diff
-      (exec/debug-script-raw command)
+      (debug-script-raw command)
       '[{x (freeze 1), y (freeze 2)}])))
 
 (deftest test-sample
@@ -441,7 +185,7 @@
   (let [data (io/return (repeat 1000 {:x 1, :y 2}))
         command (raw/sample$ data 0.5 {})]
     (< 490
-       (count (exec/debug-script command))
+       (count (debug-script command))
        510)))
 
 ;; ********** Set **********
@@ -455,177 +199,11 @@
                          {:x 2, :y 4}])
         command (raw/distinct$ data {})]
     (test-diff
-      (exec/debug-script command)
+      (debug-script command)
       '[(freeze {:y 2, :x 1})
         (freeze {:y 4, :x 2})])))
 
-(deftest test-union
-  (let [data1 (io/return [1 2 3])
-        data2 (io/return [2 3 4])
-        data3 (io/return [3 4 5])
-        
-        command (pig-set/union data1 data2 data3)]
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze 1) (freeze 2) (freeze 3) (freeze 4) (freeze 5)})))
-
-(deftest test-union-multiset
-  (let [data1 (io/return [1 2 3])
-        data2 (io/return [2 3 4])
-        data3 (io/return [3 4 5])
-        
-        command (pig-set/union-multiset data1 data2 data3)]
-    (test-diff
-      (sort-by second (exec/debug-script command))
-      '[(freeze 1) (freeze 2) (freeze 2)
-        (freeze 3) (freeze 3) (freeze 3)
-        (freeze 4) (freeze 4) (freeze 5)])))
-
-(deftest test-intersection
-  (let [data1 (io/return [1 2 3 3])
-        data2 (io/return [3 2 3 4 3])
-        data3 (io/return [3 4 3 5 2])
-        
-        command (pig-set/intersection data1 data2 data3)]
-    (test-diff
-      (sort-by second (exec/debug-script command))
-      '[(freeze 2) (freeze 3)])))
-
-(deftest test-intersection-multiset
-  (let [data1 (io/return [1 2 3 3])
-        data2 (io/return [3 2 3 4 3])
-        data3 (io/return [3 4 3 5 2])
-        
-        command (pig-set/intersection-multiset data1 data2 data3)]
-    (test-diff
-      (sort-by second (exec/debug-script command))
-      '[(freeze 2) (freeze 3) (freeze 3)])))
-
-(deftest test-difference
-  (let [data1 (io/return [1 2 3 3 3 4 5])
-        data2 (io/return [1 2])
-        data3 (io/return [4 5])
-        
-        command (pig-set/difference data1 data2 data3)]
-    (test-diff
-      (sort-by second (exec/debug-script command))
-      '[(freeze 3)])))
-
-(deftest test-difference-multiset
-  (let [data1 (io/return [1 2 3 3 3 4 5])
-        data2 (io/return [1 2 3])
-        data3 (io/return [3 4 5])
-        
-        command (pig-set/difference-multiset data1 data2 data3)]
-    (test-diff
-      (sort-by second (exec/debug-script command))
-      '[(freeze 3)])))
-
 ;; ********** Join **********
-
-(deftest test-group-by
-  (with-redefs [pigpen.raw/pigsym (pigsym-inc)]
-    (let [data (io/return [{:a 1 :b 2}
-                           {:a 1 :b 3}
-                           {:a 2 :b 4}])
-          
-          command (pig-join/group-by :a data)]
-
-      (test-diff
-        (set (exec/debug-script command))
-        '#{(freeze [1 ({:a 1, :b 2} {:a 1, :b 3})])
-           (freeze [2 ({:a 2, :b 4})])}))))
-
-(deftest test-into
-  (let [data (io/return-raw
-               (map freeze-vals '[{value 2}
-                                  {value 4}
-                                  {value 6}]))
-        
-        command (pig-join/into [] data)]
-
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze [2 4 6])])))
-
-(deftest test-reduce
-  (let [data (io/return-raw
-               (map freeze-vals '[{value 2}
-                                  {value 4}
-                                  {value 6}]))
-        
-        command (pig-join/reduce conj [] data)]
-
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze [2 4 6])]))
-  
-  (let [data (io/return-raw
-               (map freeze-vals '[{value 2}
-                                  {value 4}
-                                  {value 6}]))
-        
-        command (pig-join/reduce + data)]
-
-    (test-diff
-      (exec/debug-script command)
-      '[(freeze 12)])))
-
-(deftest test-fold
-  (let [data (io/return [{:k :foo, :v 1}
-                         {:k :foo, :v 2}
-                         {:k :foo, :v 3}
-                         {:k :bar, :v 4}
-                         {:k :bar, :v 5}])]
-    (let [command (->> data
-                    (pig-join/group-by :k
-                                       {:fold (fold/fold-fn + (fn [acc value] (+ acc (:v value))))}))]
-      (is (= (set (exec/debug-script command))
-             '#{(freeze [:foo 6])
-                (freeze [:bar 9])})))
-    
-    (let [command (->> data
-                    (pig-join/group-by :k
-                                       {:fold (fold/fold-fn (fn ([] 0)
-                                                              ([a b] (+ a b)))
-                                                                (fn [acc _] (inc acc)))}))]
-      (is (= (set (exec/debug-script command))
-             '#{(freeze [:bar 2])
-                (freeze [:foo 3])})))
-    
-    (let [command (->> data
-                    (pig-join/group-by :k
-                                       {:fold (fold/count)}))]
-      (is (= (set (exec/debug-script command))
-             '#{(freeze [:bar 2])
-                (freeze [:foo 3])}))))
-  
-  (let [data0 (io/return [{:k :foo, :a 1}
-                          {:k :foo, :a 2}
-                          {:k :foo, :a 3}
-                          {:k :bar, :a 4}
-                          {:k :bar, :a 5}])
-        data1 (io/return [{:k :foo, :b 1}
-                          {:k :foo, :b 2}
-                          {:k :bar, :b 3}
-                          {:k :bar, :b 4}
-                          {:k :bar, :b 5}])
-        command (pig-join/cogroup [(data0 :on :k, :required true, :fold (->> (fold/map :a) (fold/sum)))
-                                   (data1 :on :k, :required true, :fold (->> (fold/map :b) (fold/sum)))]
-                                  vector)]
-    (is (= (set (exec/debug-script command))
-           '#{(freeze [:foo 6 3])
-              (freeze [:bar 9 12])})))
-  
-  (let [data (io/return [1 2 3 4])
-        command (pig-join/fold + data)]
-    (is (= (exec/debug-script command)
-           '[(freeze 10)])))
-  
-  (let [data (io/return [1 2 3 4])
-        command (pig-join/fold (fold/count) data)]
-   (is (= (exec/debug-script command)
-          '[(freeze 4)]))))
 
 (deftest test-cogroup
   (with-redefs [pigpen.raw/pigsym (pigsym-inc)]
@@ -644,7 +222,7 @@
                               {})]
 
       (test-diff
-        (set (exec/debug-script-raw command))
+        (set (debug-script-raw command))
         '#{{group (freeze :a)
             [[return1] key] (bag (tuple (freeze :a)) (tuple (freeze :a)))
             [[return1] value] (bag (tuple (freeze 2)) (tuple (freeze 4)))
@@ -655,265 +233,6 @@
             [[return1] value] (bag (tuple (freeze 6)))
             [[return2] key] (bag (tuple (freeze :b)) (tuple (freeze :b)))
             [[return2] value] (bag (tuple (freeze 10)) (tuple (freeze 12)))}}))))
-
-(deftest test-cogroup+
-  (let [data1 (io/return [{:a 1, :b 2}
-                          {:a 1, :b 4}
-                          {:a 2, :b 6}])
-        data2 (io/return [{:a 1, :b 8}
-                          {:a 2, :b 10}
-                          {:a 2, :b 12}])
-        
-        command (pig-join/cogroup [(data1 :on :a) (data2 :on :a)] vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [1 ({:a 1, :b 2} {:a 1, :b 4}) ({:a 1, :b 8})])
-         (freeze [2 ({:a 2, :b 6}) ({:a 2, :b 10} {:a 2, :b 12})])})))
-
-(deftest test-cogroup-inner
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/cogroup [(data1 :by :k :type :required)
-                                   (data2 :by :k :type :required)]
-                                  vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [:i
-                  [{:k :i, :v 5} {:k :i, :v 7}]
-                  [{:k :i, :v 6} {:k :i, :v 8}]])})))
-
-(deftest test-cogroup-left-outer
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/cogroup [(data1 :on :k :type :required)
-                                   (data2 :on :k :type :optional)]
-                                  vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [nil
-                  [{:k nil, :v 1} {:k nil, :v 3}]
-                  nil])
-         (freeze [:i
-                  [{:k :i, :v 5} {:k :i, :v 7}]
-                  [{:k :i, :v 6} {:k :i, :v 8}]])
-         (freeze [:l
-                  [{:k :l, :v 9} {:k :l, :v 11}]
-                  nil])})))
-
-(deftest test-cogroup-right-outer
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/cogroup [(data1 :on :k :type :optional)
-                                   (data2 :on :k :type :required)]
-                                  vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [nil
-                  nil
-                  [{:k nil, :v 2} {:k nil, :v 4}]])
-         (freeze [:i
-                  [{:k :i, :v 5} {:k :i, :v 7}]
-                  [{:k :i, :v 6} {:k :i, :v 8}]])
-         (freeze [:r
-                  nil
-                  [{:k :r, :v 10} {:k :r, :v 12}]])})))
-
-(deftest test-cogroup-full-outer
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/cogroup [(data1 :on :k :type :optional)
-                                   (data2 :on :k :type :optional)]
-                                  vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [nil
-                  [{:k nil, :v 1} {:k nil, :v 3}]
-                  nil])
-         (freeze [nil
-                  nil
-                  [{:k nil, :v 2} {:k nil, :v 4}]])
-         (freeze [:i
-                  [{:k :i, :v 5} {:k :i, :v 7}]
-                  [{:k :i, :v 6} {:k :i, :v 8}]])
-         (freeze [:l
-                  [{:k :l, :v 9} {:k :l, :v 11}]
-                  nil])
-         (freeze [:r
-                  nil
-                  [{:k :r, :v 10} {:k :r, :v 12}]])})))
-
-(deftest test-cogroup-inner-join-nils
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/cogroup [(data1 :on :k :type :required)
-                                   (data2 :on :k :type :required)]
-                                  vector
-                                  {:join-nils true})]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [nil
-                  [{:k nil, :v 1} {:k nil, :v 3}]
-                  [{:k nil, :v 2} {:k nil, :v 4}]])
-         (freeze [:i
-                  [{:k :i, :v 5} {:k :i, :v 7}]
-                  [{:k :i, :v 6} {:k :i, :v 8}]])})))
-
-(deftest test-cogroup-left-outer-join-nils
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/cogroup [(data1 :on :k :type :required)
-                                   (data2 :on :k :type :optional)]
-                                  vector
-                                  {:join-nils true})]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [nil
-                  [{:k nil, :v 1} {:k nil, :v 3}]
-                  [{:k nil, :v 2} {:k nil, :v 4}]])
-         (freeze [:i
-                  [{:k :i, :v 5} {:k :i, :v 7}]
-                  [{:k :i, :v 6} {:k :i, :v 8}]])
-         (freeze [:l
-                  [{:k :l, :v 9} {:k :l, :v 11}]
-                  nil])})))
-
-(deftest test-cogroup-right-outer-join-nils
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/cogroup [(data1 :on :k :type :optional)
-                                   (data2 :on :k :type :required)]
-                                  vector
-                                  {:join-nils true})]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [nil
-                  [{:k nil, :v 1} {:k nil, :v 3}]
-                  [{:k nil, :v 2} {:k nil, :v 4}]])
-         (freeze [:i
-                  [{:k :i, :v 5} {:k :i, :v 7}]
-                  [{:k :i, :v 6} {:k :i, :v 8}]])
-         (freeze [:r
-                  nil
-                  [{:k :r, :v 10} {:k :r, :v 12}]])})))
-
-(deftest test-cogroup-full-outer-join-nils
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/cogroup [(data1 :on :k :type :optional)
-                                   (data2 :on :k :type :optional)]
-                                  vector
-                                  {:join-nils true})]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [nil
-                  [{:k nil, :v 1} {:k nil, :v 3}]
-                  [{:k nil, :v 2} {:k nil, :v 4}]])
-         (freeze [:i
-                  [{:k :i, :v 5} {:k :i, :v 7}]
-                  [{:k :i, :v 6} {:k :i, :v 8}]])
-         (freeze [:l
-                  [{:k :l, :v 9} {:k :l, :v 11}]
-                  nil])
-         (freeze [:r
-                  nil
-                  [{:k :r, :v 10} {:k :r, :v 12}]])})))
 
 (deftest test-join
   (with-redefs [pigpen.raw/pigsym (pigsym-inc)]
@@ -932,396 +251,9 @@
                              {})]
       
       (test-diff
-        (set (exec/debug-script-raw command))
+        (set (debug-script-raw command))
         #{'{[[return1 key]] (freeze :a), [[return1 value]] (freeze 2), [[return2 key]] (freeze :a), [[return2 value]] (freeze 8)}
           '{[[return1 key]] (freeze :a), [[return1 value]] (freeze 4), [[return2 key]] (freeze :a), [[return2 value]] (freeze 8)}
           '{[[return1 key]] (freeze :b), [[return1 value]] (freeze 6), [[return2 key]] (freeze :b), [[return2 value]] (freeze 10)}
           '{[[return1 key]] (freeze :b), [[return1 value]] (freeze 6), [[return2 key]] (freeze :b), [[return2 value]] (freeze 12)}}))))
 
-(deftest test-join+
-  (let [data1 (io/return [{:a 1, :b 2}
-                          {:a 1, :b 4}
-                          {:a 2, :b 6}])
-        data2 (io/return [{:a 1, :b 8}
-                          {:a 2, :b 10}
-                          {:a 2, :b 12}])
-        
-        command (pig-join/join [(data1 :on :a) (data2 :on :a)] vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [{:a 1, :b 2} {:a 1, :b 8}])
-         (freeze [{:a 1, :b 4} {:a 1, :b 8}])
-         (freeze [{:a 2, :b 6} {:a 2, :b 10}])
-         (freeze [{:a 2, :b 6} {:a 2, :b 12}])})))
-
-(deftest test-join-identity
-  (let [data1 (io/return [1 2])
-        data2 (io/return [2 3])
-        
-        command (pig-join/join [(data1)
-                                (data2)]
-                               vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [2 2])})))
-
-(deftest test-join-inner-implicit
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/join [(data1 :on :k)
-                                (data2 :on :k)]
-                               vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [{:k :i, :v 5} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 8}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 8}])})))
-
-(deftest test-join-self
-  (let [data (io/return [0 1 2])
-        command (pig-join/join [(data)
-                                (data)]
-                               vector)]
-    (is (= (exec/dump command)
-           [[2 2] [0 0] [1 1]]))))
-
-(deftest test-cogroup-self
-  (let [data (io/return [0 1 2])
-        command (pig-join/cogroup [(data)
-                                   (data)]
-                                  vector)]
-    (is (= (exec/dump command)
-           '[[2 (2) (2)] [0 (0) (0)] [1 (1) (1)]]))))
-
-(deftest test-cogroup-self+fold
-  (let [data (io/return [0 1 2])
-        command (pig-join/cogroup [(data :fold (fold/count))
-                                   (data :fold (fold/count))]
-                                  vector)]
-    (is (= (exec/dump command)
-           '[[2 1 1] [0 1 1] [1 1 1]]))))
-
-(deftest test-join-inner
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/join [(data1 :on :k :type :required)
-                                (data2 :on :k :type :required)]
-                               vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [{:k :i, :v 5} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 8}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 8}])})))
-
-(deftest test-join-left-outer
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/join [(data1 :on :k :type :required)
-                                (data2 :on :k :type :optional)]
-                               vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [{:k nil, :v 1} nil])
-         (freeze [{:k nil, :v 3} nil])
-         (freeze [{:k :i, :v 5} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 8}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 8}])
-         (freeze [{:k :l, :v 9} nil])
-         (freeze [{:k :l, :v 11} nil])})))
-
-(deftest test-join-right-outer
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/join [(data1 :on :k :type :optional)
-                                (data2 :on :k :type :required)]
-                               vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [nil {:k nil, :v 2}])
-         (freeze [nil {:k nil, :v 4}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 8}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 8}])
-         (freeze [nil {:k :r, :v 10}])
-         (freeze [nil {:k :r, :v 12}])})))
-
-(deftest test-join-full-outer
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/join [(data1 :on :k :type :optional)
-                                (data2 :on :k :type :optional)]
-                               vector)]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [{:k nil, :v 1} nil])
-         (freeze [{:k nil, :v 3} nil])
-         (freeze [nil {:k nil, :v 2}])
-         (freeze [nil {:k nil, :v 4}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 8}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 8}])
-         (freeze [{:k :l, :v 9} nil])
-         (freeze [{:k :l, :v 11} nil])
-         (freeze [nil {:k :r, :v 10}])
-         (freeze [nil {:k :r, :v 12}])})))
-
-(deftest test-join-inner-join-nils
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/join [(data1 :on :k :type :required)
-                                (data2 :on :k :type :required)]
-                               vector
-                               {:join-nils true})]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [{:k nil, :v 1} {:k nil, :v 2}])
-         (freeze [{:k nil, :v 3} {:k nil, :v 2}])
-         (freeze [{:k nil, :v 1} {:k nil, :v 4}])
-         (freeze [{:k nil, :v 3} {:k nil, :v 4}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 8}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 8}])})))
-
-(deftest test-join-left-outer-join-nils
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/join [(data1 :on :k :type :required)
-                                (data2 :on :k :type :optional)]
-                               vector
-                               {:join-nils true})]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [{:k nil, :v 1} {:k nil, :v 2}])
-         (freeze [{:k nil, :v 3} {:k nil, :v 2}])
-         (freeze [{:k nil, :v 1} {:k nil, :v 4}])
-         (freeze [{:k nil, :v 3} {:k nil, :v 4}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 8}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 8}])
-         (freeze [{:k :l, :v 9} nil])
-         (freeze [{:k :l, :v 11} nil])})))
-
-(deftest test-join-right-outer-join-nils
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/join [(data1 :on :k :type :optional)
-                                (data2 :on :k :type :required)]
-                               vector
-                               {:join-nils true})]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [{:k nil, :v 1} {:k nil, :v 2}])
-         (freeze [{:k nil, :v 3} {:k nil, :v 2}])
-         (freeze [{:k nil, :v 1} {:k nil, :v 4}])
-         (freeze [{:k nil, :v 3} {:k nil, :v 4}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 8}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 8}])
-         (freeze [nil {:k :r, :v 10}])
-         (freeze [nil {:k :r, :v 12}])})))
-
-(deftest test-join-full-outer-join-nils
-  (let [data1 (io/return [{:k nil, :v 1}
-                          {:k nil, :v 3}
-                          {:k :i, :v 5}
-                          {:k :i, :v 7}
-                          {:k :l, :v 9}
-                          {:k :l, :v 11}])
-        data2 (io/return [{:k nil, :v 2}
-                          {:k nil, :v 4}
-                          {:k :i, :v 6}
-                          {:k :i, :v 8}
-                          {:k :r, :v 10}
-                          {:k :r, :v 12}])
-        
-        command (pig-join/join [(data1 :on :k :type :optional)
-                                (data2 :on :k :type :optional)]
-                               vector
-                               {:join-nils true})]
-
-    (test-diff
-      (set (exec/debug-script command))
-      '#{(freeze [{:k nil, :v 1} {:k nil, :v 2}])
-         (freeze [{:k nil, :v 3} {:k nil, :v 2}])
-         (freeze [{:k nil, :v 1} {:k nil, :v 4}])
-         (freeze [{:k nil, :v 3} {:k nil, :v 4}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 5} {:k :i, :v 8}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 6}])
-         (freeze [{:k :i, :v 7} {:k :i, :v 8}])
-         (freeze [{:k :l, :v 9} nil])
-         (freeze [{:k :l, :v 11} nil])
-         (freeze [nil {:k :r, :v 10}])
-         (freeze [nil {:k :r, :v 12}])})))
-
-(deftest test-filter-by
-  (let [data (io/return [{:k nil, :v 1}
-                         {:k nil, :v 3}
-                         {:k :i, :v 5}
-                         {:k :i, :v 7}
-                         {:k :l, :v 9}
-                         {:k :l, :v 11}])]
-
-    (testing "Normal"
-      (let [keys (io/return [:i])]
-        (test-diff
-          (set (exec/debug-script (pig-join/filter-by :k keys data)))
-          '#{(freeze {:k :i, :v 5})
-             (freeze {:k :i, :v 7})})))
-    
-    (testing "Nil keys"
-      (let [keys (io/return [:i nil])]
-        (test-diff
-          (set (exec/debug-script (pig-join/filter-by :k keys data)))
-          '#{(freeze {:k nil, :v 1})
-             (freeze {:k nil, :v 3})
-             (freeze {:k :i, :v 5})
-             (freeze {:k :i, :v 7})})))
-    
-    (testing "Duplicate keys"
-      (let [keys (io/return [:i :i])]
-        (test-diff
-          (exec/debug-script (pig-join/filter-by :k keys data))
-          '[(freeze {:k :i, :v 5})
-            (freeze {:k :i, :v 7})
-            (freeze {:k :i, :v 5})
-            (freeze {:k :i, :v 7})])))))
-
-(deftest test-remove-by
-  (let [data (io/return [{:k nil, :v 1}
-                         {:k nil, :v 3}
-                         {:k :i, :v 5}
-                         {:k :i, :v 7}
-                         {:k :l, :v 9}
-                         {:k :l, :v 11}])]
-
-    (testing "Normal"
-      (let [keys (io/return [:i])]
-          (test-diff
-            (set (exec/debug-script (pig-join/remove-by :k keys data)))
-            '#{(freeze {:k nil, :v 1})
-               (freeze {:k nil, :v 3})
-               (freeze {:k :l, :v 9})
-               (freeze {:k :l, :v 11})})))
-    
-    (testing "Nil keys"
-      (let [keys (io/return [:i nil])]
-        (test-diff
-          (set (exec/debug-script (pig-join/remove-by :k keys data)))
-          '#{(freeze {:k :l, :v 9})
-             (freeze {:k :l, :v 11})})))
-    
-    (testing "Duplicate keys"
-      (let [keys (io/return [:i :i])]
-        (test-diff
-          (set (exec/debug-script (pig-join/remove-by :k keys data)))
-          '#{(freeze {:k nil, :v 1})
-             (freeze {:k nil, :v 3})
-             (freeze {:k :l, :v 9})
-             (freeze {:k :l, :v 11})})))))


### PR DESCRIPTION
This just moves code around. local-test was actually a bunch of functional tests, so I broke it up and called them functional tests.
