### PR TITLE
Pig needs an "L" to know that a number is a long

### DIFF
--- a/src/main/clojure/pigpen/script.clj
+++ b/src/main/clojure/pigpen/script.clj
@@ -62,7 +62,13 @@ See pigpen.core and pigpen.exec
  ([scope expr]
    (cond
      (nil? expr)    nil
-     (number? expr) (str expr)
+     (number? expr) (cond
+                      ;; This is not ideal, but it prevents Pig from blowing up when you use big numbers
+                      (and (instance? Long expr)
+                           (not (< Integer/MIN_VALUE expr Integer/MAX_VALUE)))
+                      (str expr "L")
+                      
+                      :else (str expr))
      (string? expr) (escape+quote expr)
      (symbol? expr) (if-let [v (scope expr)]
                       (expr->script scope v)

--- a/src/test/clojure/pigpen/script_test.clj
+++ b/src/test/clojure/pigpen/script_test.clj
@@ -33,6 +33,7 @@
   (is (= (#'pigpen.script/expr->script nil) nil))
   (is (= (#'pigpen.script/expr->script "a'b\\c") "'a\\'b\\\\c'"))
   (is (= (#'pigpen.script/expr->script 42) "42"))
+  (is (= (#'pigpen.script/expr->script 2147483648) "2147483648L"))
   (is (= (#'pigpen.script/expr->script 'foo) "foo"))
   (is (= (#'pigpen.script/expr->script '(clojure.core/let [foo '2] foo)) "2"))
   (is (= (#'pigpen.script/expr->script '(clojure.core/let [foo '2] (and (= bar foo) (> baz 3)))) "((bar == 2) AND (baz > 3))")))


### PR DESCRIPTION
Pig requires an explicit "L" after a Long to indicate that it's a Long; otherwise it blows up. I tried adding the "L" to every number to be consistent, but in Pig, 42 != 42L. So the compromise is to only add it when absolutely needed.
