### PR TITLE
Make the pigpen.jar location in the generated script configurable

### DIFF
--- a/src/main/clojure/pigpen/exec.clj
+++ b/src/main/clojure/pigpen/exec.clj
@@ -53,6 +53,9 @@ combine them. Optionally takes a map of options.
 
     :dedupe - Set to false to disable command deduping.
 
+    :pigpen-jar-location - The location where your uberjar resides.
+                           Defaults to 'pigpen.jar'.
+
   See also: pigpen.core/write-script, pigpen.core/script
 "
   {:added "0.1.0"}
@@ -80,6 +83,9 @@ combine them. Optionally takes a map of options.
              The value is a path to place the debug output.
 
     :dedupe - Set to false to disable command deduping.
+
+    :pigpen-jar-location - The location where your uberjar resides.
+                           Defaults to 'pigpen.jar'.
 
   See also: pigpen.core/generate-script, pigpen.core/script
 "

--- a/src/test/clojure/pigpen/oven_test.clj
+++ b/src/test/clojure/pigpen/oven_test.clj
@@ -88,15 +88,17 @@
 (deftest test-command->references
   
   (test-diff
-    (#'pigpen.oven/command->references (pig-raw/generate$ {}
+    (#'pigpen.oven/command->references "s3://bucket/pigpen.jar"
+                                       (pig-raw/generate$ {}
                                          [(pig-raw/projection-func$ 'foo
                                             (pig-raw/code$ String ['foo]
                                               (pig-raw/expr$ '(require '[pigpen.pig])
                                                              '(var clojure.core/prn))))] {}))
-    ["pigpen.jar"])
+    ["s3://bucket/pigpen.jar"])
   
   (test-diff
-    (#'pigpen.oven/command->references (pig-raw/store$ {} "" (pig-raw/storage$ ["my-jar.jar"] "f" []) {}))
+    (#'pigpen.oven/command->references "pigpen.jar"
+                                       (pig-raw/store$ {} "" (pig-raw/storage$ ["my-jar.jar"] "f" []) {}))
     ["my-jar.jar"]))
 
 (deftest test-braise
@@ -126,7 +128,7 @@
           (pig-raw/load$ "foo" '[foo] test-storage {})
           (pig-raw/store$ % "bar" test-storage {})
           (#'pigpen.oven/braise %)
-          (#'pigpen.oven/extract-references %)
+          (#'pigpen.oven/extract-references "pigpen.jar" %)
           (map #(select-keys % [:type :id :ancestors :references :jar]) %))
         '[{:type :register
            :jar "ref"}


### PR DESCRIPTION
Use the `:pigpen-jar-location` option to generate a script with a location other than 'pigpen.jar'
