### PR TITLE
load-lazy returns one character at a time

### DIFF
--- a/src/main/clojure/pigpen/io.clj
+++ b/src/main/clojure/pigpen/io.clj
@@ -92,9 +92,9 @@ split by the specified regex delimiter. The default delimiter is #\"\\t\".
   See also: pigpen.core/load-string, pigpen.core/load-clj, pigpen.core/load-json
 "
   {:added "0.1.0"}
-  ([location] (load-tsv location #"\t"))
+  ([location] (load-tsv location "\t"))
   ([location delimiter]
-    (load-string* location [] `(fn [~'s] (if ~'s (clojure.string/split ~'s ~delimiter))))))
+    (load-string* location [] `(fn [~'s] (if ~'s (pigpen.extensions.core/structured-split ~'s ~delimiter))))))
 
 (defn load-clj
   "Loads clojure data from a file. Each line should contain one value and will
@@ -137,19 +137,15 @@ read-str as a map. The default options used are {:key-fn keyword}.
 Loads data from a tsv file. Each line is returned as a lazy seq, split by
 the specified delimiter. The default delimiter is \\t.
 
-  Note: The delimiter is wrapped with [^ ]+ to negate it for use with re-seq.
-        Thus, only simple delimiters are supported. Experimental & might not work.
-
   Note: Internally this uses \\u0000 as the split char so Pig won't split the line.
         This won't work for files that actually have that char
 
   See also: pigpen.core/load-tsv
 "
   {:added "0.1.0"}
-  ([location] (load-lazy location #"\t"))
+  ([location] (load-lazy location "\t"))
   ([location delimiter]
-    (let [delimiter (java.util.regex.Pattern/compile (str "[^" delimiter "]"))]
-      (load-string* location [] `(fn [~'s] (re-seq ~delimiter ~'s))))))
+    (load-string* location [] `(fn [~'s] (pigpen.extensions.core/lazy-split ~'s ~delimiter)))))
 
 (defn store-binary
   "Stores data in the PigPen binary format. This is generally not used

--- a/src/test/clojure/pigpen/extensions/core_test.clj
+++ b/src/test/clojure/pigpen/extensions/core_test.clj
@@ -47,3 +47,33 @@
           "a" :bar "a:bar"
           "b" :foo "b:foo"
           "b" :bar "b:bar"])))
+
+(deftest test-lazy-split
+  (testing "split on pattern"
+    (is (not (realized? (rest (lazy-split "\tabc\t\t123\t" #"\t")))))
+    (is (= ["" "abc" "" "123" ""] (lazy-split "\tabc\t\t123\t" #"\t")))
+    (is (= ["^" "abc" "" "123" ""] (lazy-split "^\tabc\t\t123\t" #"\t")))
+    (is (= ["" "abc" "" "123" "$"] (lazy-split "\tabc\t\t123\t$" #"\t")))
+    (is (= ["Escaped comma\\, does not" "break up fields" "with the right regex"] (lazy-split "Escaped comma\\, does not,break up fields,with the right regex" #"(?<!\\),")))
+    (is (= ["\tdifferent\t" "\tdelimiter\t"] (lazy-split "\tdifferent\t<==>\tdelimiter\t" #"<==>"))))
+
+  (testing "split on string"
+    (is (not (realized? (rest (lazy-split "\tabc\t\t123\t" "\t")))))
+    (is (= ["" "abc" "" "123" ""] (lazy-split "\tabc\t\t123\t" "\t")))
+    (is (= ["^" "abc" "" "123" ""] (lazy-split "^\tabc\t\t123\t" "\t")))
+    (is (= ["" "abc" "" "123" "$"] (lazy-split "\tabc\t\t123\t$" "\t")))
+    (is (= ["\tdifferent\t" "\tdelimiter\t"] (lazy-split "\tdifferent\t<==>\tdelimiter\t" "<==>")))))
+
+(deftest test-structured-split
+  (testing "split on pattern"
+    (is (= ["" "abc" "" "123" ""] (structured-split "\tabc\t\t123\t" #"\t")))
+    (is (= ["^" "abc" "" "123" ""] (structured-split "^\tabc\t\t123\t" #"\t")))
+    (is (= ["" "abc" "" "123" "$"] (structured-split "\tabc\t\t123\t$" #"\t")))
+    (is (= ["Escaped comma\\, does not" "break up fields" "with the right regex"] (structured-split "Escaped comma\\, does not,break up fields,with the right regex" #"(?<!\\),")))
+    (is (= ["\tdifferent\t" "\tdelimiter\t"] (structured-split "\tdifferent\t<==>\tdelimiter\t" #"<==>"))))
+
+  (testing "split on string"
+    (is (= ["" "abc" "" "123" ""] (structured-split "\tabc\t\t123\t" "\t")))
+    (is (= ["^" "abc" "" "123" ""] (structured-split "^\tabc\t\t123\t" "\t")))
+    (is (= ["" "abc" "" "123" "$"] (structured-split "\tabc\t\t123\t$" "\t")))
+    (is (= ["\tdifferent\t" "\tdelimiter\t"] (structured-split "\tdifferent\t<==>\tdelimiter\t" "<==>")))))

--- a/src/test/clojure/pigpen/io_test.clj
+++ b/src/test/clojure/pigpen/io_test.clj
@@ -98,7 +98,7 @@
       '{:type :bind
         :id bind2
         :description nil
-        :func (pigpen.pig/map->bind (clojure.core/fn [s] (if s (clojure.string/split s "\\t"))))
+        :func (pigpen.pig/map->bind (clojure.core/fn [s] (if s (pigpen.extensions.core/structured-split s "\t"))))
         :args [value]
         :requires []
         :fields [value]
@@ -183,7 +183,7 @@
       '{:type :bind
        :id bind2
        :description nil
-       :func (pigpen.pig/map->bind (clojure.core/fn [s] (clojure.core/re-seq "[^\\t]" s)))
+       :func (pigpen.pig/map->bind (clojure.core/fn [s] (pigpen.extensions.core/lazy-split s "\t")))
        :args [value]
        :requires []
        :fields [value]


### PR DESCRIPTION
load-lazy returns all characters between delimiters, instead of one at a time.
The existing implementation when loading

```
abcd\t1234
```

would return `[("a" "b" "c" "d" "1" "2" "3" "4")]`, but should return `[("abcd" "1234")]`.
