### PR TITLE
Use \n as a fake record delimiter instead of \0

### DIFF
--- a/pigpen-core/src/main/clojure/pigpen/local.clj
+++ b/pigpen-core/src/main/clojure/pigpen/local.clj
@@ -238,10 +238,15 @@ See pigpen.core and pigpen.exec
 (defmethod load-reader :default [location]
   (io/reader location))
 
+(defn ^:private parse-delimiter [d]
+  (case d
+    "\\n" #"\n"
+    "\\t" #"\t"
+    (Pattern/compile (str (read-string d)))))
+
 (defmethod load "PigStorage" [{:keys [location fields storage opts]}]
   (let [{:keys [cast]} opts
-        delimiter (-> storage :args first edn/read-string)
-        delimiter (if delimiter (Pattern/compile (str delimiter)) #"\t")]
+        delimiter (or (some-> storage :args first parse-delimiter) #"\t")]
     (reify PigPenLocalLoader
       (locations [_]
         (load-list location))

--- a/pigpen-core/src/main/clojure/pigpen/raw.clj
+++ b/pigpen-core/src/main/clojure/pigpen/raw.clj
@@ -114,7 +114,7 @@ building blocks for more complex operations.")
   (storage$ [] "PigStorage" []))
 
 (def string-storage
-  (storage$ [] "PigStorage" ["\\u0000"]))
+  (storage$ [] "PigStorage" ["\\n"]))
 
 (defn load$
   [location fields storage opts]

--- a/pigpen-core/src/test/clojure/pigpen/io_test.clj
+++ b/pigpen-core/src/test/clojure/pigpen/io_test.clj
@@ -87,7 +87,7 @@
                      :storage {:type :storage
                                :references []
                                :func "PigStorage"
-                               :args ["\\u0000"]}
+                               :args ["\\n"]}
                      :opts {:type :load-opts
                             :cast "chararray"}}]})))
 
@@ -114,7 +114,7 @@
                      :storage {:type :storage
                                :references []
                                :func "PigStorage"
-                               :args ["\\u0000"]}
+                               :args ["\\n"]}
                      :opts {:type :load-opts
                             :cast "chararray"}}]})))
 
@@ -141,7 +141,7 @@
                      :storage {:type :storage
                                :references []
                                :func "PigStorage"
-                               :args ["\\u0000"]}
+                               :args ["\\n"]}
                      :opts {:type :load-opts
                             :cast "chararray"}}]})))
 
@@ -172,7 +172,7 @@
                      :storage {:type :storage
                                :references []
                                :func "PigStorage"
-                               :args ["\\u0000"]}
+                               :args ["\\n"]}
                      :opts {:type :load-opts
                             :cast "chararray"}}]})))
 
@@ -199,7 +199,7 @@
                     :storage {:type :storage
                               :references []
                               :func "PigStorage"
-                              :args ["\\u0000"]}
+                              :args ["\\n"]}
                     :opts {:type :load-opts
                            :cast "chararray"}}]})))
 


### PR DESCRIPTION
PigStorage requires a delimiter, so we had been using \0 as this is rare in actual files. Turns out we can use \n because this, by definition, will never appear in a line.
