### PR TITLE
Fix a bug in fold/avg

### DIFF
--- a/pigpen-core/src/main/clojure/pigpen/fold.clj
+++ b/pigpen-core/src/main/clojure/pigpen/fold.clj
@@ -362,15 +362,14 @@ fold operation to compose.
   {:added "0.2.0"}
   ([]
     (fold-fn (fn
-               ([] nil)
-               ([[s0 c0] [s1 c1]]
-                 [(+ s0 s1) (+ c0 c1)]))
-             (fn [[s c :as acc] val]
-               (if acc
-                 [(+ s val) (inc c)]
-                 [val 1]))
+               ([] [0 0])
+               ([l r]
+                 (mapv + l r)))
+             (fn [[s c] val]
+               [(+ s val) (inc c)])
              (fn [[s c]]
-               (/ s c))))
+               (when (pos? c)
+                 (/ s c)))))
   ([fold]
     (comp-fold-new fold (avg))))
 

--- a/pigpen-core/src/test/clojure/pigpen/fold_test.clj
+++ b/pigpen-core/src/test/clojure/pigpen/fold_test.clj
@@ -149,7 +149,15 @@
   (let [data (pig/return [1 2 3 4])
         command (pig/fold (fold/avg) data)]
     (is (= (pig/dump command)
-           [5/2]))))
+           [5/2])))
+  
+  (let [foos (pig/return [1 2 2 3 3 3])
+        bars (pig/return [1 1 1 2 2 3])
+        command (pig/cogroup [(foos :on identity, :fold (fold/sum))
+                              (bars :on identity, :fold (fold/avg))]
+                             (fn [key f b] [key f b]))]
+    (is (= (set (pig/dump command))
+           #{[1 1 1] [2 4 2] [3 9 3]}))))
 
 (deftest test-top
   (let [data (pig/return [1 2 3 4])


### PR DESCRIPTION
Found a bug in fold/avg where if somehow a seed value is passed to the combiner, it would throw an exception. I'm fairly confident this only happened locally, but took the opportunity to simplify the logic.
