### PR TITLE
Update code$ to not refer to pig classes. Using keywords instead

### DIFF
--- a/pigpen-core/src/main/clojure/pigpen/join.clj
+++ b/pigpen-core/src/main/clojure/pigpen/join.clj
@@ -63,7 +63,7 @@ coerced to ::nil so they can be differentiated from outer joins later."
 
 (defn ^:private projection-fold [fold field alias]
   (if fold
-    (raw/projection-func$ alias (raw/code$ "Algebraic" [field] (raw/expr$ "" fold)))
+    (raw/projection-func$ alias (raw/code$ :algebraic [field] (raw/expr$ "" fold)))
     (raw/projection-field$ field alias)))
 
 (defn group*

--- a/pigpen-core/src/main/clojure/pigpen/raw.clj
+++ b/pigpen-core/src/main/clojure/pigpen/raw.clj
@@ -87,13 +87,11 @@ building blocks for more complex operations.")
 
 (defn code$
   "Execute custom code in a script."
-  [^Class return args expr]
-  {:pre [expr return (sequential? args)]}
+  [udf args expr]
+  {:pre [expr (keyword? udf) (sequential? args)]}
   ^:pig {:type :code
          :expr expr
-         :return (if (string? return)
-                   return
-                   (last (clojure.string/split (.getName return) #"\.")))
+         :udf udf
          :args (vec args)})
 
 ;; ********** IO **********

--- a/pigpen-core/src/test/clojure/pigpen/join_test.clj
+++ b/pigpen-core/src/test/clojure/pigpen/join_test.clj
@@ -104,7 +104,7 @@
                                     :alias value1
                                     :code {:type :code
                                            :args [[[generate2] value]]
-                                           :return "Algebraic"
+                                           :udf :algebraic
                                            :expr {:init ""
                                                   :func (pigpen.runtime/with-ns pigpen.join-test
                                                           (fold/fold-fn +))}}}]
@@ -207,7 +207,7 @@
                        :alias value
                        :code {:type :code
                              :args [[[r0] value]]
-                             :return "Algebraic"
+                             :udf :algebraic
                              :expr {:init ""
                                     :func (pigpen.runtime/with-ns pigpen.join-test
                                             (pigpen.join/fold-fn* clojure.core/identity + + clojure.core/identity))}}}]
@@ -250,7 +250,7 @@
                                    {:type :projection-func
                                     :alias value1
                                     :code {:type :code
-                                           :return "Algebraic"
+                                           :udf :algebraic
                                            :args [[[generate2] value]]
                                            :expr {:init ""
                                                   :func (pigpen.runtime/with-ns pigpen.join-test
@@ -258,7 +258,7 @@
                                    {:type :projection-func
                                     :alias value2
                                     :code {:type :code
-                                           :return "Algebraic"
+                                           :udf :algebraic
                                            :args [[[generate4] value]]
                                            :expr {:init ""
                                                   :func (pigpen.runtime/with-ns pigpen.join-test

--- a/pigpen-core/src/test/clojure/pigpen/raw_test.clj
+++ b/pigpen-core/src/test/clojure/pigpen/raw_test.clj
@@ -54,11 +54,11 @@
 
 (deftest test-code$
   (test-diff
-    (code$ String ["a" 'b '[c d]]
+    (code$ :normal ["a" 'b '[c d]]
            (expr$ '(require '[pigpen.pig])
                   '(var clojure.core/prn)))
     '{:type :code
-      :return "String"
+      :udf :normal
       :expr {:init (require (quote [pigpen.pig]))
              :func (var clojure.core/prn)}
       :args ["a" b [c d]]}))
@@ -136,26 +136,26 @@
 (deftest test-projection-func$
   (test-diff
     (projection-func$ 'value
-                      (code$ String ['value]
+                      (code$ :normal ['value]
                              (expr$ `(require '[pigpen.pig]) `identity)))
     '{:type :projection-func
       :code {:type :code
              :expr {:init (clojure.core/require (quote [pigpen.pig]))
                     :func clojure.core/identity}
-             :return "String"
+             :udf :normal
              :args [value]}
       :alias value}))
 
 (deftest test-projection-flat$
   (test-diff
     (projection-flat$ 'value
-                      (code$ String ['value]
+                      (code$ :normal ['value]
                              (expr$ `(require '[pigpen.pig]) `identity)))
     '{:type :projection-flat
       :code {:type :code
              :expr {:init (clojure.core/require (quote [pigpen.pig]))
                     :func clojure.core/identity}
-             :return "String"
+             :udf :normal
              :args [value]}
       :alias value}))
 
@@ -254,7 +254,7 @@
   (with-redefs [pigpen.raw/pigsym pigsym-zero]
     (test-diff
       (filter$ {:fields ['value]}
-               (code$ String ['value]
+               (code$ :normal ['value]
                       (expr$ `(require '[pigpen.pig]) `identity))
                {})
       '{:type :filter
@@ -266,7 +266,7 @@
         :code {:type :code
                :expr {:init (clojure.core/require (quote [pigpen.pig]))
                       :func clojure.core/identity}
-               :return "String"
+               :udf :normal
                :args [value]}
         :opts {:type :filter-opts}})))
 

--- a/pigpen-pig/src/main/clojure/pigpen/local.clj
+++ b/pigpen-pig/src/main/clojure/pigpen/local.clj
@@ -54,13 +54,14 @@ See pigpen.core and pigpen.exec
 
 (def create-udf
   (memoize
-    (fn ^EvalFunc [scope return init func]
-      (eval `(new ~(symbol (str "pigpen.PigPenFn" return)) ~(str init) ~(str func))))))
+    (fn ^EvalFunc [scope udf init func]
+      (let [udf (pig/udf-lookup udf)]
+        (eval `(new ~(symbol udf) ~(str init) ~(str func)))))))
 
 ;; TODO add option to skip this for faster execution
-(defn ^:private eval-code [{:keys [return expr args]} values]
+(defn ^:private eval-code [{:keys [udf expr args]} values]
   (let [{:keys [init func]} expr
-        ^EvalFunc instance (create-udf udf-scope return init func)
+        ^EvalFunc instance (create-udf udf-scope udf init func)
         ^Tuple tuple (->> args
                        (map #(if ((some-fn symbol? vector?) %) (dereference (values %)) %))
                        (apply pig/tuple))]

--- a/pigpen-pig/src/main/clojure/pigpen/oven.clj
+++ b/pigpen-pig/src/main/clojure/pigpen/oven.clj
@@ -24,8 +24,7 @@ number of optimizations and transforms to the graph.
   (:refer-clojure :exclude [ancestors])
   (:require [clojure.set]
             [pigpen.raw :as raw]
-            [pigpen.code :as code])
-  (:import [org.apache.pig.data DataBag]))
+            [pigpen.code :as code]))
 
 (set! *warn-on-reflection* true)
 
@@ -341,7 +340,7 @@ number of optimizations and transforms to the graph.
                  (pigpen.pig/post-process ~last-field-type)])
         
         projection (raw/projection-flat$ last-field
-                     (raw/code$ DataBag first-args
+                     (raw/code$ :sequence first-args
                        (raw/expr$ requires func)))
         
         description (->> commands (map :description) (clojure.string/join))]

--- a/pigpen-pig/src/main/clojure/pigpen/pig.clj
+++ b/pigpen-pig/src/main/clojure/pigpen/pig.clj
@@ -392,6 +392,13 @@ serialization info."
 
 ;; **********
 
+(defn udf-lookup [type]
+  (case type
+    :normal "pigpen.PigPenFnDataByteArray"
+    :sequence "pigpen.PigPenFnDataBag"
+    :boolean "pigpen.PigPenFnBoolean"
+    :algebraic "pigpen.PigPenFnAlgebraic"))
+
 (defn eval-udf
   [func ^Tuple t]
   "Evaluates a pig tuple as a clojure function. The first element of the tuple

--- a/pigpen-pig/src/main/clojure/pigpen/script.clj
+++ b/pigpen-pig/src/main/clojure/pigpen/script.clj
@@ -110,12 +110,13 @@ See pigpen.core and pigpen.exec
 ;; ********** Util **********
 
 (defmethod command->script :code
-  [{:keys [return expr args]} state]
-  {:pre [return expr args]}
+  [{:keys [udf expr args]} state]
+  {:pre [udf expr args]}
   (let [id (raw/pigsym "udf")
         {:keys [init func]} expr
-        pig-args (->> args (map format-field) (join ", "))]
-    [(str "DEFINE " id " pigpen.PigPenFn" return "(" (escape+quote init) "," (escape+quote func) ");\n\n")
+        pig-args (->> args (map format-field) (join ", "))
+        udf (pigpen.pig/udf-lookup udf)]
+    [(str "DEFINE " id " " udf "(" (escape+quote init) "," (escape+quote func) ");\n\n")
      (str id "(" pig-args ")")]))
 
 (defmethod command->script :register

--- a/pigpen-pig/src/test/clojure/pigpen/local_test.clj
+++ b/pigpen-pig/src/test/clojure/pigpen/local_test.clj
@@ -39,7 +39,7 @@
 
 (deftest test-eval-code
   
-  (let [code (raw/code$ DataBag '[x y]
+  (let [code (raw/code$ :normal '[x y]
                (raw/expr$ '(require (quote [pigpen.pig]))
                           '(pigpen.pig/exec
                              [(pigpen.pig/pre-process :frozen)

--- a/pigpen-pig/src/test/clojure/pigpen/oven_test.clj
+++ b/pigpen-pig/src/test/clojure/pigpen/oven_test.clj
@@ -91,7 +91,7 @@
     (#'pigpen.oven/command->references "s3://bucket/pigpen.jar"
                                        (pig-raw/generate$ {}
                                          [(pig-raw/projection-func$ 'foo
-                                            (pig-raw/code$ String ['foo]
+                                            (pig-raw/code$ :normal ['foo]
                                               (pig-raw/expr$ '(require '[pigpen.pig])
                                                              '(var clojure.core/prn))))] {}))
     ["s3://bucket/pigpen.jar"])
@@ -507,7 +507,7 @@
                                                                             (pigpen.runtime/mapcat->bind (pigpen.runtime/with-ns pigpen.oven-test vector))
                                                                             (pigpen.runtime/map->bind clojure.core/pr-str)
                                                                             (pigpen.pig/post-process :native)])}
-                                             :return "DataBag"
+                                             :udf :sequence
                                              :args [value]}
                                       :alias value}]
                        :type :generate

--- a/pigpen-pig/src/test/clojure/pigpen/script_test.clj
+++ b/pigpen-pig/src/test/clojure/pigpen/script_test.clj
@@ -46,7 +46,7 @@
            (command->script '{:type :code
                               :expr {:init (require '[pigpen.pig])
                                      :func identity}
-                              :return DataByteArray
+                              :udf :normal
                               :args []}
                             {})))))
 
@@ -141,7 +141,7 @@
                               :code {:type :code
                                      :expr {:init nil
                                             :func (fn [x] (* x x))}
-                                     :return "DataByteArray"
+                                     :udf :normal
                                      :args ["a" a]}
                               :alias b}
                             {})))))
@@ -163,7 +163,7 @@ generate0 = FOREACH relation0 GENERATE
                                              :code {:type :code
                                                     :expr {:init nil
                                                            :func (fn [x] (* x x))}
-                                                    :return "DataByteArray"
+                                                    :udf :normal
                                                     :args ["a" a]}
                                              :alias b}]}
                             {})))))
@@ -181,7 +181,7 @@ generate0 = FOREACH relation0 GENERATE
                                              :code {:type :code
                                                     :expr {:init nil
                                                            :func (fn [x] [x x])}
-                                                    :return "DataBag"
+                                                    :udf :sequence
                                                     :args ["a" a]}
                                              :alias b}]}
                             {})))))
@@ -239,7 +239,7 @@ filter0 = FILTER relation0 BY udf1('a', a);\n\n"
                               :code {:type :code
                                      :expr {:init nil
                                             :func (fn [x] (even? x))}
-                                     :return "Boolean"
+                                     :udf :boolean
                                      :args ["a" a]}}
                             {})))))
 


### PR DESCRIPTION
Pig needs to know the return type of the UDF. Other platforms may or may not need this distinction, but now it doesn't refer to specific pig classes.

cc @pkozikow
