### PR TITLE
handle forward compatibility with default fields correctly

### DIFF
--- a/pigpen-avro/resources/example_compatibility_new.avsc
+++ b/pigpen-avro/resources/example_compatibility_new.avsc
@@ -1,0 +1,119 @@
+{
+  "type": "record",
+  "name": "ExampleRecord",
+  "namespace": "com.example",
+  "fields": [
+    {
+      "name": "browserTimestamp",
+      "type": "long"
+    },
+    {
+      "name": "rawHash",
+      "type": {
+        "type": "map",
+        "values": "string"
+      }
+    },
+    {
+      "name": "metadata",
+      "type": {
+        "type": "record",
+        "name": "SharedRecordSchema",
+        "namespace": "com.example",
+        "fields": [
+          {
+            "name": "schema_id",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "name": "requestSpan",
+      "type": {
+        "type": "record",
+        "name": "ExampleNestedRecord",
+        "fields": [
+          {
+            "name": "metadata",
+            "type": "com.example.SharedRecordSchema"
+          },
+          {
+            "name": "spanId",
+            "type": "string"
+          },
+          {
+            "name": "parentSpanId",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "unhandledException",
+            "type": [
+              "null",
+              {
+                "type": "record",
+                "name": "Exception",
+                "fields": [
+                  {
+                    "name": "exceptionClass",
+                    "type": "string"
+                  },
+                  {
+                    "name": "exceptionMessage",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "default": null
+                  },
+                  {
+                    "name": "exceptionStack",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "handledExceptions",
+            "type": [
+              "null",
+              {
+                "type": "array",
+                "items": "Exception"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "panel",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "PanelInfo",
+          "fields": [
+            {
+              "name": "defOid",
+              "type": [
+                "null",
+                "long"
+              ],
+              "default": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "newFieldWithDefault",
+      "type": ["string", "null"],
+      "default": "foo"
+    }
+  ]
+}

--- a/pigpen-avro/src/test/clojure/pigpen/functional/avro_test.clj
+++ b/pigpen-avro/src/test/clojure/pigpen/functional/avro_test.clj
@@ -99,4 +99,14 @@
                             (pig/fold (fold/sum)))]
     (is (= (pig/dump query) [5671989521278]))))
 
+(deftest test-compatibility
+  (let [query (->>
+               (pig-avro/load-avro
+                "resources/example_data.avro" (slurp "resources/example_compatibility_new.avsc"))
+               (pig/map #(get % :newFieldWithDefault 0))
+               (pig/fold (fold/distinct))
+               (pigpen.oven/bake))]
+    (is (.contains (pig/generate-script query) "\"default\":\"foo\""))
+    (is (= (pig/dump query) [#{"foo"}]))))
+
 (comment (run-tests))


### PR DESCRIPTION
Avro supports reading old data with a newer schema, as long as the new schema
only adds fields and each added field has a default specified. This patch 
changes load-avro to support this feature of Avro. Fixes an issue with default
values caused by using the canonical version (intended for use in fingerprinting)
of the schema rather than the full version.