### PR TITLE
add PigPen to Cascading appliction frameworks

### DIFF
--- a/pigpen-cascading/src/main/clojure/pigpen/cascading/core.clj
+++ b/pigpen-cascading/src/main/clojure/pigpen/cascading/core.clj
@@ -24,6 +24,7 @@
            (cascading.pipe.assembly Unique Rename AggregateBy)
            (cascading.pipe.joiner BufferJoin MixedJoin)
            (cascading.scheme.hadoop TextLine)
+           (cascading.property AppProps)
            (cascading.tap Tap)
            (cascading.tap.hadoop Hfs)
            (cascading.tuple Fields)
@@ -37,6 +38,9 @@
             [pigpen.extensions.core :refer [zip]]))
 
 (set! *warn-on-reflection* true)
+
+(AppProps/addApplicationFramework nil
+  (str "PigPen:0.3.1" ))
 
 (defn cfields
   ^Fields [fields]


### PR DESCRIPTION
Cascading has a notion of frameworks used in a flow. All extensions add themselves to it (cascading-jdbc, cascading-hive, scalding, etc. etc). This small patch adds PigPen to frameworks. 

The frameworks can be seen in driven, so this is very useful for users of driven.