### PR TITLE
update to Cascading 2.7.0

### DIFF
--- a/pigpen-cascading/build.gradle
+++ b/pigpen-cascading/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     compile project(':pigpen')
 
     // Should these be provided?
-    compile 'cascading:cascading-core:2.5.1'
-    compile 'cascading:cascading-hadoop:2.5.1'
+    compile 'cascading:cascading-core:2.7.0'
+    compile 'cascading:cascading-hadoop:2.7.0'
     compile 'org.apache.hadoop:hadoop-core:1.1.2'
     compile 'org.slf4j:slf4j-log4j12:1.6.1'
 


### PR DESCRIPTION
This updates Cascading to 2.7.0, which is fully backwards compatible with 2.5.x, but contains all the latest bugfixes and a few new features.

You can find the full list of Changes here: https://github.com/Cascading/cascading/blob/2.7/CHANGES.txt