### PR TITLE
add PigPen to Cascading appliction frameworks

### DIFF
--- a/pigpen-cascading/src/main/clojure/pigpen/cascading/core.clj
+++ b/pigpen-cascading/src/main/clojure/pigpen/cascading/core.clj
@@ -40,7 +40,11 @@
 (set! *warn-on-reflection* true)
 
 (AppProps/addApplicationFramework nil
-  (str "PigPen:0.3.1" ))
+  (str "PigPen:"
+       (or (some-> PigPenFunction
+             (.getPackage)
+             (.getImplementationVersion))
+           "unknown")))
 
 (defn cfields
   ^Fields [fields]


### PR DESCRIPTION
@fs111 Is this ok? It should fetch the current version at runtime so I don't have to keep it up to date (I'm really not good at keeping stuff like this up to date). If someone is developing pigpen, then this version will be nil and it'll fall back to `"unknown"`. Is that ok or would you prefer a different default value?