### PR TITLE
Update to hadoop 2.6.0 and parquet 1.7.0

### DIFF
--- a/pigpen-cascading/build.gradle
+++ b/pigpen-cascading/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'java'
 dependencies {
     compile project(':pigpen')
 
-    // Should these be provided?
-    compile 'cascading:cascading-core:2.7.0'
-    compile 'cascading:cascading-hadoop:2.7.0'
-    compile 'org.apache.hadoop:hadoop-core:1.1.2'
+    provided 'cascading:cascading-core:2.7.0'
+    provided 'cascading:cascading-hadoop2-mr1:2.7.0'
+    provided 'org.apache.hadoop:hadoop-common:2.6.0'
+    provided 'org.apache.hadoop:hadoop-mapreduce-client-core:2.6.0'
     compile 'org.slf4j:slf4j-log4j12:1.6.1'
 
     testCompile 'criterium:criterium:0.4.3'

--- a/pigpen-hadoop/build.gradle
+++ b/pigpen-hadoop/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     compile project(':pigpen')
 
-    provided 'org.apache.hadoop:hadoop-core:1.1.2'
+    provided 'org.apache.hadoop:hadoop-common:2.6.0'
+    provided 'org.apache.hadoop:hadoop-mapreduce-client-core:2.6.0'
 }

--- a/pigpen-hadoop/src/main/clojure/pigpen/hadoop.clj
+++ b/pigpen-hadoop/src/main/clojure/pigpen/hadoop.clj
@@ -48,16 +48,18 @@
 (defn job-context
   "Create a Hadoop JobContext"
   [^Job job]
-  (JobContext.
-    (.getConfiguration job)
-    (JobID. "jt" 0)))
+  (reify JobContext
+    (getConfiguration [_]
+      (.getConfiguration job))
+    (getJobID [_]
+      (JobID. "jt" 0))))
 
 (defn task-context
   "Create a Hadoop TaskAttemptContext"
   [^Job job]
-  (TaskAttemptContext.
-    (.getConfiguration job)
-    (TaskAttemptID. "jt" 0 true 1 0)))
+  (reify TaskAttemptContext
+    (getTaskAttemptID [_]
+      (TaskAttemptID. "jt" 0 true 1 0))))
 
 (defn input-format->values
   "Uses a Hadoop InputFormat to read values from a file."

--- a/pigpen-parquet-pig/build.gradle
+++ b/pigpen-parquet-pig/build.gradle
@@ -2,12 +2,11 @@ dependencies {
     compile project(':pigpen-parquet')
     compile project(':pigpen-pig')
 
-    compile 'com.twitter:parquet-pig:1.5.0'
+    compile 'org.apache.parquet:parquet-pig:1.7.0'
 
     provided 'org.apache.pig:pig:0.13.0'
-    provided 'org.apache.hadoop:hadoop-core:1.1.2'
-    provided 'org.antlr:antlr:3.5.2'
-    provided 'log4j:log4j:1.2.17'
+    provided 'org.apache.hadoop:hadoop-common:2.6.0'
+    provided 'org.apache.hadoop:hadoop-mapreduce-client-core:2.6.0'
 
     testCompile project(path: ':pigpen', configuration: 'testOutput')
     testCompile project(path: ':pigpen-pig', configuration: 'testOutput')

--- a/pigpen-parquet-pig/src/main/clojure/pigpen/pig/parquet.clj
+++ b/pigpen-parquet-pig/src/main/clojure/pigpen/pig/parquet.clj
@@ -18,7 +18,7 @@
 
 (ns pigpen.pig.parquet
   (:require [pigpen.pig.script])
-  (:import [parquet.pig PigSchemaConverter]))
+  (:import [org.apache.parquet.pig PigSchemaConverter]))
 
 (defmethod pigpen.pig.script/storage->script [:load :parquet]
   [command]

--- a/pigpen-parquet/build.gradle
+++ b/pigpen-parquet/build.gradle
@@ -2,7 +2,9 @@ dependencies {
     compile project(':pigpen')
     compile project(':pigpen-hadoop')
 
-    compile 'com.twitter:parquet-tools:1.5.0'
+    compile 'org.apache.parquet:parquet-tools:1.7.0'
+    provided 'org.apache.hadoop:hadoop-common:2.6.0'
+    provided 'org.apache.hadoop:hadoop-mapreduce-client-core:2.6.0'
 
     testCompile project(path: ':pigpen', configuration: 'testOutput')
 }

--- a/pigpen-parquet/src/main/clojure/pigpen/local/parquet.clj
+++ b/pigpen-parquet/src/main/clojure/pigpen/local/parquet.clj
@@ -20,9 +20,9 @@
   (:require [pigpen.local]
             [pigpen.hadoop]
             [pigpen.parquet.core :as pq])
-  (:import [parquet.tools.read SimpleRecord SimpleRecord$NameValue]
+  (:import [org.apache.parquet.tools.read SimpleRecord SimpleRecord$NameValue]
            [pigpen.hadoop InputFormatLoader OutputFormatStorage]
-           [parquet.hadoop ParquetInputFormat ParquetOutputFormat]))
+           [org.apache.parquet.hadoop ParquetInputFormat ParquetOutputFormat]))
 
 (defmethod pigpen.local/load :parquet
   [{:keys [location fields]}]

--- a/pigpen-parquet/src/main/clojure/pigpen/parquet.clj
+++ b/pigpen-parquet/src/main/clojure/pigpen/parquet.clj
@@ -31,7 +31,7 @@ schemas. Start with `load-parquet` and `store-parquet`.
   (:refer-clojure :exclude [float double boolean byte-array])
   (:require [pigpen.raw :as raw]
             [pigpen.parquet.core :as pq])
-  (:import [parquet.schema
+  (:import [org.apache.parquet.schema
             MessageType GroupType
             PrimitiveType PrimitiveType$PrimitiveTypeName
             Type Type$Repetition]))

--- a/pigpen-parquet/src/main/clojure/pigpen/parquet/core.clj
+++ b/pigpen-parquet/src/main/clojure/pigpen/parquet/core.clj
@@ -17,8 +17,8 @@
 ;;
 
 (ns pigpen.parquet.core
-  (:import [parquet.io.api RecordConsumer Binary]
-           [parquet.schema
+  (:import [org.apache.parquet.io.api RecordConsumer Binary]
+           [org.apache.parquet.schema
             MessageType Type
             PrimitiveType
             PrimitiveType$PrimitiveTypeName]))

--- a/pigpen-parquet/src/main/java/pigpen/parquet/PigPenParquetWriteSupport.java
+++ b/pigpen-parquet/src/main/java/pigpen/parquet/PigPenParquetWriteSupport.java
@@ -22,11 +22,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.api.WriteSupport;
+import org.apache.parquet.io.api.RecordConsumer;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
 
-import parquet.hadoop.api.WriteSupport;
-import parquet.io.api.RecordConsumer;
-import parquet.schema.MessageType;
-import parquet.schema.MessageTypeParser;
 import clojure.lang.IFn;
 import clojure.lang.RT;
 import clojure.lang.Symbol;

--- a/pigpen-pig/build.gradle
+++ b/pigpen-pig/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     compile 'org.clojure:core.async:0.1.346.0-17112a-alpha'
 
     provided 'org.apache.pig:pig:0.13.0'
-    provided 'org.apache.hadoop:hadoop-core:1.1.2'
+    provided 'org.apache.hadoop:hadoop-common:2.6.0'
+    provided 'org.apache.hadoop:hadoop-mapreduce-client-core:2.6.0'
 
     testCompile project(path: ':pigpen', configuration: 'testOutput')
     testCompile 'org.apache.pig:pigunit:0.13.0'


### PR DESCRIPTION
cc @fs111 @pkozikow 

I attempted to update the hadoop libraries to v2, but I'm getting the following exception from the integration tests. I'm seeing a similar exception from the pig integration tests.

Do you guys know what I need to use for the requested values? I'm out till next Tuesday, so if you don't figure it out by then, I'll give it another shot.


ERROR in (cascading-pigpen-functional-map-test-test-map) (BaseFlow.java:918)
Uncaught exception, not in assertion.
expected: nil
  actual: cascading.flow.FlowException: unhandled exception
 at cascading.flow.BaseFlow.complete (BaseFlow.java:918)
    sun.reflect.NativeMethodAccessorImpl.invoke0 (NativeMethodAccessorImpl.java:-2)
    sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:57)
    sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    java.lang.reflect.Method.invoke (Method.java:606)
    clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:93)
    clojure.lang.Reflector.invokeNoArgInstanceMember (Reflector.java:313)
    pigpen.cascading.functional_test$run_flow.invoke (functional_test.clj:33)
    pigpen.cascading.functional_test$run_flow__GT_output.invoke (functional_test.clj:39)
    pigpen.cascading.functional_test$fn$reify__11868.dump (functional_test.clj:57)
    pigpen.functional.map_test$test_map.invoke (map_test.clj:31)
    pigpen.cascading.functional_test/fn (functional_test.clj:45)
    clojure.test$test_var$fn__7187.invoke (test.clj:704)
    clojure.test$test_var.invoke
 (test.clj:704)
    pigpen.cascading.functional_test$cascading_pigpen_functional_map_test_test_map.invoke (functional_test.clj:45)
    pigpen.cascading.functional_test$eval12324.invoke (NO_SOURCE_FILE:1)
    clojure.lang.Compiler.eval (Compiler.java:6703)
    clojure.lang.Compiler.eval (Compiler.java:6666)
    clojure.core$eval.invoke (core.clj:2927)
    clojure.main$repl$read_eval_print__6625$fn__6628.invoke (main.clj:239)
    clojure.main$repl$read_eval_print__6625.invoke (main.clj:239)
    clojure.main$repl$fn__6634.invoke (main.clj:257)
    clojure.main$repl.doInvoke (main.clj:257)
    clojure.lang.RestFn.invoke (RestFn.java:1096)
    clojure.tools.nrepl.middleware.interruptible_eval$evaluate$fn__1024.invoke (interruptible_eval.clj:56)
    clojure.lang.AFn.applyToHelper (AFn.java:152)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.core$apply.invoke (core.clj:624)
    clojure.core$with_bindings_STAR_.doInvoke (core.clj:1862)
    clojure.lang.RestFn.invoke (RestFn.java:425)
    clojure.tools.nrepl.middleware.interruptible_eval$evaluate.invoke
 (interruptible_eval.clj:41)
    clojure.tools.nrepl.middleware.interruptible_eval$interruptible_eval$fn__1065$fn__1068.invoke (interruptible_eval.clj:171)
    clojure.core$comp$fn__4192.invoke (core.clj:2402)
    clojure.tools.nrepl.middleware.interruptible_eval$run_next$fn__1058.invoke (interruptible_eval.clj:138)
    clojure.lang.AFn.run (AFn.java:22)
    java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1145)
    java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:615)
    java.lang.Thread.run (Thread.java:744)
Caused by: java.io.IOException: Cannot initialize Cluster. Please check your configuration for mapreduce.framework.name and the correspond server addresses.
 at org.apache.hadoop.mapreduce.Cluster.initialize (Cluster.java:120)
    org.apache.hadoop.mapreduce.Cluster.<init> (Cluster.java:82)
    org.apache.hadoop.mapreduce.Cluster.<init> (Cluster.java:75)
    org.apache.hadoop.mapred.JobClient.init (JobClient.java:470)
    org.apache.hadoop.mapred.JobClient.<init>
 (JobClient.java:449)
    cascading.flow.hadoop.planner.HadoopFlowStepJob.internalNonBlockingStart (HadoopFlowStepJob.java:107)
    cascading.flow.planner.FlowStepJob.blockOnJob (FlowStepJob.java:236)
    cascading.flow.planner.FlowStepJob.start (FlowStepJob.java:162)
    cascading.flow.planner.FlowStepJob.call (FlowStepJob.java:124)
    cascading.flow.planner.FlowStepJob.call (FlowStepJob.java:43)
    java.util.concurrent.FutureTask.run (FutureTask.java:262)
    java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1145)
    java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:615)
    java.lang.Thread.run (Thread.java:744)