### PR TITLE
Remove unused bytes->json

### DIFF
--- a/pigpen-pig/src/main/clojure/pigpen/pig/runtime.clj
+++ b/pigpen-pig/src/main/clojure/pigpen/pig/runtime.clj
@@ -89,11 +89,6 @@ possible as it's used at runtime."
   [b]
   (clojure.string/join (mapv #(format "%02X" %) b)))
 
-(defn bytes->json
-  "Convert bytes into a string & then parses json"
-  [b]
-  (if b (json/read-json (String. (bytes b)))))
-
 (defn cast-bytes
   "Converts a byte array into the specified type. Similar to a cast in pig."
   [type value]


### PR DESCRIPTION
When we attempted to upgrade to pigpen 3.0 we were getting the following confusing error at compile time: 
Exception in thread "main" java.lang.ClassNotFoundException: pigpen.pig.runtime, compiling:(pigpen/pig/script.clj:138:13) ...

The script and runtime were both in same jar file and was quite confusing.  We got same error trying to require pigpen.pig.runtime in the repl and determined the issue was due caused by bytes-json-> referencing a method that no longer exists. 

read-json was replaced by read-str and deprecated from clojure/data.json in v0.2.1. 
https://github.com/clojure/data.json/commit/6ee71009946731d89ef8f98e7b659fa82443b6a2

It looks as if you are using v0.2.5. In theory it was moved to another file and loaded into the ns for compatibility, so it should still exist although deprecated. However, when I require clojure.data.json from a repl it does not appear to define read-json despite the call in to load the compat shim and for whatever reason is the source of the above ClassNotFoundException.  Updating this to read-str resolved the issue.  

This method was not used anywhere in pigpen so I removed the method entirely rather than update it.  If there is some reason it should be kept then it should be changed to read-str.  


