### PR TITLE
Nippy performance: disable compression but keep header

### DIFF
--- a/pigpen-cascading/src/main/clojure/pigpen/cascading/runtime.clj
+++ b/pigpen-cascading/src/main/clojure/pigpen/cascading/runtime.clj
@@ -38,7 +38,7 @@
     (-> value (OperationUtil/getBytes) thaw)))
 
 (defn cs-freeze [value]
-  (BytesWritable. (freeze value)))
+  (BytesWritable. (freeze value {:compressor nil})))
 
 (defn ^:private cs-freeze-with-nils [value]
   (if-not (nil? value)


### PR DESCRIPTION
In reference to #168:

This commit benefits performance (esp. write performance) over a possible minor increase
in serialized data size  (usu. <5% extra size).

Note that by *keeping the header*, we retain the option of changing compression
strategies later in a fully back and forward compatible way.