### PR TITLE
Tune nippy performance

### DIFF
--- a/pigpen-cascading/src/main/clojure/pigpen/cascading/runtime.clj
+++ b/pigpen-cascading/src/main/clojure/pigpen/cascading/runtime.clj
@@ -35,10 +35,14 @@
 (extend-protocol HybridToClojure
   BytesWritable
   (rt/hybrid->clojure [value]
-    (-> value (OperationUtil/getBytes) thaw)))
+    (-> value
+      (OperationUtil/getBytes)
+      (thaw {:compressor nil
+             :encryptor  nil
+             :v1-compatibility? false}))))
 
 (defn cs-freeze [value]
-  (BytesWritable. (freeze value)))
+  (BytesWritable. (freeze value {:compressor nil, :skip-header? true})))
 
 (defn ^:private cs-freeze-with-nils [value]
   (if-not (nil? value)

--- a/pigpen-core/build.gradle
+++ b/pigpen-core/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     compile 'org.clojure:clojure:1.6.0'
     compile 'org.clojure:data.json:0.2.5'
     compile 'org.clojure:data.csv:0.1.2'
-    compile 'com.taoensso:nippy:2.9.1'
+    compile 'com.taoensso:nippy:2.10.0'
     compile 'prismatic:schema:0.3.3'
 }
 

--- a/pigpen-pig/src/main/clojure/pigpen/pig/runtime.clj
+++ b/pigpen-pig/src/main/clojure/pigpen/pig/runtime.clj
@@ -105,9 +105,11 @@ possible as it's used at runtime."
 (extend-protocol HybridToClojure
   DataByteArray
   (rt/hybrid->clojure [^DataByteArray value]
-    (-> value (.get) (thaw {:compressor nil
-                            :encryptor  nil
-                            :v1-compatibility? false})))
+    (-> value
+      (.get)
+      (thaw {:compressor nil
+             :encryptor  nil
+             :v1-compatibility? false})))
   Tuple
   (rt/hybrid->clojure [^Tuple value]
     (->> value (.getAll) (mapv rt/hybrid->clojure)))

--- a/pigpen-pig/src/main/clojure/pigpen/pig/runtime.clj
+++ b/pigpen-pig/src/main/clojure/pigpen/pig/runtime.clj
@@ -61,7 +61,7 @@ possible as it's used at runtime."
     (.add tuple)))
 
 (defn ^:private pig-freeze [value]
-  (DataByteArray. (freeze value)))
+  (DataByteArray. (freeze value {:compressor nil, :skip-header? true})))
 
 (defn ^:private pig-freeze-with-nils [value]
   (if-not (nil? value)
@@ -105,7 +105,9 @@ possible as it's used at runtime."
 (extend-protocol HybridToClojure
   DataByteArray
   (rt/hybrid->clojure [^DataByteArray value]
-    (-> value (.get) thaw))
+    (-> value (.get) (thaw {:compressor nil
+                            :encryptor  nil
+                            :v1-compatibility? false})))
   Tuple
   (rt/hybrid->clojure [^Tuple value]
     (->> value (.getAll) (mapv rt/hybrid->clojure)))


### PR DESCRIPTION
cc @ptaoussanis (I updated a second location where freeze & thaw were used)

cc @bcotton 

Changes:
  * Bumped Nippy dependency to latest stable release (v2.10) (nb: requires Clojure 1.5+)
  * Tuned `freeze`/`thaw` opts for performance

Specifically:

1. `freeze {:skip-header? true}` - saves 4 bytes per payload + *slightly* faster. This
   kills support for data versioning and dynamic compression selection.
2. `freeze {:compressor nil}` - should significantly improve freeze performance (~20%) at
   an insignificant increase to payload size (~5%). A good trade assuming job data doesn't
   grow into the megabyte range.
3. `thaw {:compressor nil, :encryptor nil}` - necessary because of [1]
4. `thaw {:v1-compatibility? false}` - good hygiene if you're not thawing any legacy data