### PR TITLE
small doc-string fix, and Parquet example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,52 @@ To use the parquet loader, add this to your dependencies:
 [com.netflix.pigpen/pigpen-parquet-pig "0.3.3"]
 ```
 
+Here an example of how to write parquet data.
+
+``` clj
+(require '[pigpen.core :as pig])
+(require '[pigpen.parquet :as pqt])
+
+;;
+;; assuming that `data` is in tuples
+;;
+;; [["John" "Smith" 28]
+;;  ["Jane" "Doe"   21]]
+
+(defn save-to-parquet
+  [output-file data]
+  (->> data
+       ;; turning tuples into a map
+       (pig/map (partial zipmap [:firstname :lastname :age]))
+       ;; then storing to Parquet files
+       (pqt/store-parquet
+        output-file
+        (pqt/message "test-schema"
+                     ;; the field names here MUST match the map's keys
+                     (pqt/binary "firstname")
+                     (pqt/binary "lastname")
+                     (pqt/int64  "age")))))
+```
+
+
+And how to load the records back:
+
+``` clj
+(defn load-from-parquet
+  [input-file]
+  ;; the output will be a sequence of maps
+  (pqt/load-parquet
+   input-file
+   (pqt/message "test-schema"
+                (pqt/binary "firstname")
+                (pqt/binary "lastname")
+                (pqt/int64  "age"))))
+```
+
+
 And check out the [`pigpen.parquet`](http://netflix.github.io/PigPen/pigpen.parquet.html) namespace for usage.
 
-_Note: Avro is currently only supported by Pig_
+_Note: Parquet is currently only supported by Pig_
 
 ## Avro
 

--- a/pigpen-parquet/src/main/clojure/pigpen/parquet.clj
+++ b/pigpen-parquet/src/main/clojure/pigpen/parquet.clj
@@ -108,7 +108,7 @@ the parquet column names. The parameter `schema` is a parquet schema.
 
   Example:
 
-    (load-parquet \"input.pq\" (message (int64 \"value\")))
+    (load-parquet \"input.pq\" (message \"schema-name\" (int64 \"value\")))
 
   See also: pigpen.parquet/message for schema details
 
@@ -130,7 +130,7 @@ map with keywords matching the parquet columns to be stored. The parameter
 
   Example:
 
-    (store-parquet \"output.pq\" (message (int64 \"value\")) foo)
+    (store-parquet \"output.pq\" (message \"schema-name\" (int64 \"value\")) foo)
 
   See also: pigpen.parquet/message for schema details
 


### PR DESCRIPTION
Hi,
just added a code example for how to load/write Parquet data for the README,
and a small update to the doc-string.

Bruno