### PR TITLE
Add Group archive URL to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ _Note: PigPen is **not** a Clojure wrapper for writing Pig scripts you can hand 
 # Questions & Complaints
 
   * pigpen-support@googlegroups.com
+  * Group discussion archives can be accessed [here](https://groups.google.com/forum/#!forum/pigpen-support)
 
 # Artifacts
 


### PR DESCRIPTION
I know this seems minor - but there's education value in reading some of the archives, and they are surprisingly hard to find on Google until you land on a specific thread.